### PR TITLE
Fix UI one bound duration.

### DIFF
--- a/js/ui_translator.js
+++ b/js/ui_translator.js
@@ -1375,13 +1375,13 @@ class TranslatorVisitor extends toolkit.QubecTalkVisitor {
   visitDuringWithMin(ctx) {
     const self = this;
     const lower = ctx.lower.accept(self);
-    const upper = (engine) => engine.getEndYear();
+    const upper = null;
     return self.buildDuring(lower, upper);
   }
 
   visitDuringWithMax(ctx) {
     const self = this;
-    const lower = (engine) => engine.getStartYear();
+    const lower = null;
     const upper = ctx.upper.accept(self);
     return self.buildDuring(lower, upper);
   }


### PR DESCRIPTION
Fix an issue with translating from UI defintion of duration to code duration which seems to break when a min / max as opposed to full range is provided.