### PR TITLE
Require valid code at end of file

### DIFF
--- a/js/compiler.js
+++ b/js/compiler.js
@@ -1244,7 +1244,9 @@ class CompileVisitor extends toolkit.QubecTalkVisitor {
 
     for (let i = 0; i < numStanzas; i++) {
       const newStanza = ctx.getChild(i).accept(self);
-      stanzasByName.set(newStanza.name, newStanza);
+      if (newStanza !== undefined) {
+        stanzasByName.set(newStanza.name, newStanza);
+      }
     }
 
     const execute = () => {

--- a/js/ui_translator.js
+++ b/js/ui_translator.js
@@ -2824,7 +2824,9 @@ class TranslatorVisitor extends toolkit.QubecTalkVisitor {
 
     for (let i = 0; i < numStanzas; i++) {
       const newStanza = ctx.getChild(i).accept(self);
-      stanzasByName.set(newStanza.getName(), newStanza);
+      if (newStanza !== undefined) {
+        stanzasByName.set(newStanza.getName(), newStanza);
+      }
     }
 
     if (!stanzasByName.has("default")) {

--- a/language/QubecTalk.g4
+++ b/language/QubecTalk.g4
@@ -417,5 +417,5 @@ substanceStatement: (capStatement | changeStatement | equalsStatement | initialC
  * -------------
  **/
 
-program: stanza+;
+program: stanza* EOF;
 


### PR DESCRIPTION
I can't quite recall if this was @avanscoyoc or @mzomer but thanks for highlighting this but. This PR requires ANTLR to report broken code between the final stanza and EOF to report an error within the code editor. Prior to this PR, some error messages would get suppressed.