### PR TITLE
Command count display in tab.

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,9 +93,21 @@
                     <ul id="consumption-tabs" class="tabs" data-tabs>
                       <li><a data-tabby-default href="#consumption-general">General</a></li>
                       <li><a href="#consumption-equipment">Equipment</a></li>
-                      <li><a href="#consumption-start">Set (<span id="consumption-set-count"></span>)</a></li>
-                      <li><a href="#consumption-change">Change (<span id="consumption-change-count"></span>)</a></li>
-                      <li><a href="#consumption-limit">Limit (<span id="consumption-limit-count"></span>)</a></li>
+                      <li>
+                        <a href="#consumption-start"
+                          >Set (<span id="consumption-set-count">0</span>)</a
+                        >
+                      </li>
+                      <li>
+                        <a href="#consumption-change"
+                          >Change (<span id="consumption-change-count">0</span>)</a
+                        >
+                      </li>
+                      <li>
+                        <a href="#consumption-limit"
+                          >Limit (<span id="consumption-limit-count">0</span>)</a
+                        >
+                      </li>
                     </ul>
                     <div id="consumption-general">
                       <div class="instructions">
@@ -424,11 +436,27 @@
                   <div class="contents">
                     <ul id="policy-tabs" class="tabs" data-tabs>
                       <li><a data-tabby-default href="#policy-general">General</a></li>
-                      <li><a href="#policy-recycle">Recycle (<span id="policy-recycle-count">0</span>)</a></li>
-                      <li><a href="#policy-replace">Replace (<span id="policy-replace-count">0</span>)</a></li>
-                      <li><a href="#policy-set">Set (<span id="policy-set-count">0</span>)</a></li>
-                      <li><a href="#policy-change">Change (<span id="policy-change-count">0</span>)</a></li>
-                      <li><a href="#policy-limit">Limit (<span id="policy-limit-count">0</span>)</a></li>
+                      <li>
+                        <a href="#policy-recycle"
+                          >Recycle (<span id="policy-recycle-count">0</span>)</a
+                        >
+                      </li>
+                      <li>
+                        <a href="#policy-replace"
+                          >Replace (<span id="policy-replace-count">0</span>)</a
+                        >
+                      </li>
+                      <li>
+                        <a href="#policy-set">Set (<span id="policy-set-count">0</span>)</a>
+                      </li>
+                      <li>
+                        <a href="#policy-change"
+                          >Change (<span id="policy-change-count">0</span>)</a
+                        >
+                      </li>
+                      <li>
+                        <a href="#policy-limit">Limit (<span id="policy-limit-count">0</span>)</a>
+                      </li>
                     </ul>
                     <div id="policy-general">
                       <div class="instructions">

--- a/index.html
+++ b/index.html
@@ -424,11 +424,11 @@
                   <div class="contents">
                     <ul id="policy-tabs" class="tabs" data-tabs>
                       <li><a data-tabby-default href="#policy-general">General</a></li>
-                      <li><a href="#policy-recycle">Recycle</a></li>
-                      <li><a href="#policy-replace">Replace</a></li>
-                      <li><a href="#policy-set">Set</a></li>
-                      <li><a href="#policy-change">Change</a></li>
-                      <li><a href="#policy-limit">Limit</a></li>
+                      <li><a href="#policy-recycle">Recycle (<span id="policy-recycle-count">0</span>)</a></li>
+                      <li><a href="#policy-replace">Replace (<span id="policy-replace-count">0</span>)</a></li>
+                      <li><a href="#policy-set">Set (<span id="policy-set-count">0</span>)</a></li>
+                      <li><a href="#policy-change">Change (<span id="policy-change-count">0</span>)</a></li>
+                      <li><a href="#policy-limit">Limit (<span id="policy-limit-count">0</span>)</a></li>
                     </ul>
                     <div id="policy-general">
                       <div class="instructions">

--- a/index.html
+++ b/index.html
@@ -93,9 +93,9 @@
                     <ul id="consumption-tabs" class="tabs" data-tabs>
                       <li><a data-tabby-default href="#consumption-general">General</a></li>
                       <li><a href="#consumption-equipment">Equipment</a></li>
-                      <li><a href="#consumption-start">Set</a></li>
-                      <li><a href="#consumption-change">Change</a></li>
-                      <li><a href="#consumption-limit">Limit</a></li>
+                      <li><a href="#consumption-start">Set (<span id="consumption-set-count"></span>)</a></li>
+                      <li><a href="#consumption-change">Change (<span id="consumption-change-count"></span>)</a></li>
+                      <li><a href="#consumption-limit">Limit (<span id="consumption-limit-count"></span>)</a></li>
                     </ul>
                     <div id="consumption-general">
                       <div class="instructions">

--- a/js/ui_editor.js
+++ b/js/ui_editor.js
@@ -154,8 +154,9 @@ function getSanitizedFieldValue(selection) {
  * @param {string} itemTemplate - HTML template for list items.
  * @param {Array} items - Array of items to populate list.
  * @param {Function} uiInit - Callback to initialize each item's UI.
+ * @param {Function} removeCallback - Callback to invoke if item removed.
  */
-function setListInput(listSelection, itemTemplate, items, uiInit) {
+function setListInput(listSelection, itemTemplate, items, uiInit, removeCallback) {
   listSelection.innerHTML = "";
   const addItem = (item) => {
     const newDiv = document.createElement("div");
@@ -168,6 +169,7 @@ function setListInput(listSelection, itemTemplate, items, uiInit) {
     deleteLink.addEventListener("click", (event) => {
       event.preventDefault();
       newDiv.remove();
+      removeCallback(item);
     });
   };
   items.forEach(addItem);
@@ -833,11 +835,14 @@ class ConsumptionListPresenter {
       (x) => x.getRecharge().getValue(),
     );
 
+    const removeCallback = () => self._updateCounts();
+
     setListInput(
       self._dialog.querySelector(".level-list"),
       document.getElementById("set-command-template").innerHTML,
       objToShow === null ? [] : objToShow.getSetVals(),
       initSetCommandUi,
+      removeCallback,
     );
 
     setListInput(
@@ -845,6 +850,7 @@ class ConsumptionListPresenter {
       document.getElementById("change-command-template").innerHTML,
       objToShow === null ? [] : objToShow.getChanges(),
       initChangeCommandUi,
+      removeCallback,
     );
 
     setListInput(
@@ -852,6 +858,7 @@ class ConsumptionListPresenter {
       document.getElementById("limit-command-template").innerHTML,
       objToShow === null ? [] : objToShow.getLimits(),
       (item, root) => initLimitCommandUi(item, root, self._getCodeObj()),
+      removeCallback,
     );
 
     self._dialog.showModal();
@@ -1237,11 +1244,14 @@ class PolicyListPresenter {
       .text((x) => x)
       .property("selected", (x) => x === substanceName);
 
+    const removeCallback = () => self._updateCounts();
+
     setListInput(
       self._dialog.querySelector(".recycling-list"),
       document.getElementById("recycle-command-template").innerHTML,
       targetSubstance === null ? [] : targetSubstance.getRecycles(),
       initRecycleCommandUi,
+      removeCallback,
     );
 
     setListInput(
@@ -1249,6 +1259,7 @@ class PolicyListPresenter {
       document.getElementById("replace-command-template").innerHTML,
       targetSubstance === null ? [] : targetSubstance.getReplaces(),
       (item, root) => initReplaceCommandUi(item, root, self._getCodeObj()),
+      removeCallback,
     );
 
     setListInput(
@@ -1256,6 +1267,7 @@ class PolicyListPresenter {
       document.getElementById("set-command-template").innerHTML,
       targetSubstance === null ? [] : targetSubstance.getSetVals(),
       initSetCommandUi,
+      removeCallback,
     );
 
     setListInput(
@@ -1263,6 +1275,7 @@ class PolicyListPresenter {
       document.getElementById("change-command-template").innerHTML,
       targetSubstance === null ? [] : targetSubstance.getChanges(),
       initChangeCommandUi,
+      removeCallback,
     );
 
     setListInput(
@@ -1270,6 +1283,7 @@ class PolicyListPresenter {
       document.getElementById("limit-command-template").innerHTML,
       targetSubstance === null ? [] : targetSubstance.getLimits(),
       (item, root) => initLimitCommandUi(item, root, self._getCodeObj()),
+      removeCallback,
     );
 
     self._dialog.showModal();

--- a/js/ui_editor.js
+++ b/js/ui_editor.js
@@ -1143,8 +1143,11 @@ class PolicyListPresenter {
       event.preventDefault();
     });
 
-    const updateReminders = () => self._reminderPresenter.update();
-    const setupListButton = buildSetupListButton(updateReminders);
+    const updateHints = () => {
+      self._reminderPresenter.update();
+      self._updateCounts();
+    };
+    const setupListButton = buildSetupListButton(updateHints);
 
     const addRecyclingButton = self._root.querySelector(".add-recycling-button");
     const recyclingList = self._root.querySelector(".recycling-list");
@@ -1271,6 +1274,7 @@ class PolicyListPresenter {
 
     self._dialog.showModal();
     self._reminderPresenter.update();
+    self._updateCounts();
   }
 
   /**

--- a/js/ui_editor.js
+++ b/js/ui_editor.js
@@ -260,6 +260,27 @@ function setDuring(selection, command, defaultVal) {
 }
 
 /**
+ * Build a function which updates displays of command counts.
+ *
+ * @param dialog - Selection over the dialog in which the command count
+ *     displays should be updated.
+ * @returns Funciton which takes a string list selector and a string display
+ *     selector. That function will put the count of commands found in the
+ *     list selector into the display selector.
+ */
+function buildUpdateCount(dialog) {
+  return (listSelector, displaySelector) => {
+    const listSelection = dialog.querySelector(listSelector);
+    const displaySelection = dialog.querySelector(displaySelector);
+
+    const listItems = Array.of(...listSelection.querySelectorAll(".dialog-list-item"));
+    const listCount = listItems.map((x) => 1).reduce((a, b) => a + b, 0);
+
+    displaySelection.innerHTML = listCount;
+  };
+}
+
+/**
  * Manages the UI for listing and editing applications.
  *
  * Manages the UI for listing and editing applications where these refer to
@@ -665,13 +686,15 @@ class ConsumptionListPresenter {
       event.preventDefault();
     });
 
-    const hideEmbedReminder = () => {
+    const updateHints = () => {
       const embedReminders = self._root.querySelectorAll(".embed-reminder");
       embedReminders.forEach((reminder) => {
         reminder.style.display = "none";
       });
+
+      self._updateCounts();
     };
-    const setupListButton = buildSetupListButton(hideEmbedReminder);
+    const setupListButton = buildSetupListButton(updateHints);
 
     const addLevelButton = self._root.querySelector(".add-start-button");
     const levelList = self._root.querySelector(".level-list");
@@ -832,6 +855,7 @@ class ConsumptionListPresenter {
 
     self._dialog.showModal();
     self._reminderPresenter.update();
+    self._updateCounts();
   }
 
   /**
@@ -958,6 +982,20 @@ class ConsumptionListPresenter {
     limits.forEach((x) => substanceBuilder.addCommand(x));
 
     return substanceBuilder.build(true);
+  }
+
+  /**
+   * Updates the UI to display the count of commands in each list.
+   * 
+   * @private
+   */
+  _updateCounts() {
+    const self = this;
+
+    const updateCount = buildUpdateCount(self._dialog);
+    updateCount(".level-list", "#consumption-set-count");
+    updateCount(".change-list", "#consumption-change-count");
+    updateCount(".limit-list", "#consumption-limit-count");
   }
 }
 

--- a/js/ui_editor.js
+++ b/js/ui_editor.js
@@ -74,7 +74,7 @@ function setupDurationSelector(newDiv) {
  * Build a function which sets up a list button with add/delete functionality.
  *
  * @param {Function} postCallback - Function to call after each list item UI is
- *     initialized. If not given, will use a no-op.
+ *     initialized or removed. If not given, will use a no-op.
  */
 function buildSetupListButton(postCallback) {
   /**
@@ -98,6 +98,7 @@ function buildSetupListButton(postCallback) {
       deleteLink.addEventListener("click", (event) => {
         event.preventDefault();
         newDiv.remove();
+        postCallback();
       });
 
       initUiCallback(null, newDiv);

--- a/js/ui_editor.js
+++ b/js/ui_editor.js
@@ -1925,8 +1925,7 @@ function initLimitCommandUi(itemObj, root, codeObj) {
     new EngineNumber(1, "mt"),
     (x) => x.getValue(),
   );
-  setFieldValue(<replit_final_file>
-(root.querySelector(".displacing-input"), itemObj, "", (x) =>
+  setFieldValue(root.querySelector(".displacing-input"), itemObj, "", (x) =>
     x.getDisplacing() === null ? "" : x.getDisplacing(),
   );
   setDuring(root.querySelector(".duration-subcomponent"), itemObj, new YearMatcher(2, 10));

--- a/js/ui_editor.js
+++ b/js/ui_editor.js
@@ -986,7 +986,7 @@ class ConsumptionListPresenter {
 
   /**
    * Updates the UI to display the count of commands in each list.
-   * 
+   *
    * @private
    */
   _updateCounts() {

--- a/js/ui_editor.js
+++ b/js/ui_editor.js
@@ -1345,6 +1345,21 @@ class PolicyListPresenter {
     codeObj.insertPolicy(self._editingName, policy);
     self._onCodeObjUpdate(codeObj);
   }
+
+  /**
+   * Updates the UI to display the count of commands in each list.
+   *
+   * @private
+   */
+  _updateCounts() {
+    const self = this;
+    const updateCount = buildUpdateCount(self._dialog);
+    updateCount(".recycling-list", "#policy-recycle-count");
+    updateCount(".replace-list", "#policy-replace-count");
+    updateCount(".level-list", "#policy-set-count");
+    updateCount(".change-list", "#policy-change-count");
+    updateCount(".limit-list", "#policy-limit-count");
+  }
 }
 
 /**
@@ -1910,7 +1925,8 @@ function initLimitCommandUi(itemObj, root, codeObj) {
     new EngineNumber(1, "mt"),
     (x) => x.getValue(),
   );
-  setFieldValue(root.querySelector(".displacing-input"), itemObj, "", (x) =>
+  setFieldValue(<replit_final_file>
+(root.querySelector(".displacing-input"), itemObj, "", (x) =>
     x.getDisplacing() === null ? "" : x.getDisplacing(),
   );
   setDuring(root.querySelector(".duration-subcomponent"), itemObj, new YearMatcher(2, 10));

--- a/style/style.css
+++ b/style/style.css
@@ -4,7 +4,7 @@
 }
 
 dialog {
-  max-width: 500px;
+  max-width: 600px;
   z-index: 1;
 }
 


### PR DESCRIPTION
Thanks @felimomo for the suggestion! Unfortunately, I won't be able to implement the exact suggestion for scrolling through the tabs due to some accessibility concerns but I am adding an indicator in the tab name showing how many commands you've added in each. I'm hopeful that addresses the underlying suggestion of helping folks remember where they put each of their commands when they go back to edit a policy or consumption entry. Thank you again!