### PR TITLE
Constrain the filter set.

### DIFF
--- a/js/report_data.js
+++ b/js/report_data.js
@@ -622,6 +622,21 @@ class ReportDataWrapper {
   }
 
   /**
+   * Get the name of the first scenario available  without applying any filter.
+   *
+   * @returns {string|null} The first scenario name or null if no scenarios
+   *     present.
+   */
+  getFirstScenario() {
+    const self = this;
+    const scenarios = self.getScenarios(undefined);
+    for (const scenario of scenarios) {
+      return scenario;
+    }
+    return null;
+  }
+
+  /**
    * Get applications matching a given filter set.
    *
    * @param {FilterSet} filterSet - The filter criteria to apply.

--- a/js/results.js
+++ b/js/results.js
@@ -97,7 +97,7 @@ class ResultsPresenter {
   /**
    * Show simulation results.
    *
-   * @param {Object} results - Results data to display.
+   * @param {ReportDataWrapper} results - Results data to display.
    */
   showResults(results) {
     const self = this;
@@ -114,8 +114,29 @@ class ResultsPresenter {
    */
   _onUpdateFilterSet(newFilterSet) {
     const self = this;
-    self._filterSet = newFilterSet;
+    self._filterSet = self._constrainFilterSet(newFilterSet);
     self._updateInternally();
+  }
+
+  /**
+   * Constrain the filter set to avoid more difficult to interpret charts.
+   *
+   * Ensure that the filter set does not have both all scenarios and a non-
+   * scenario dimension value.
+   */
+  _constrainFilterSet(filterSet) {
+    const self = this;
+
+    const isAllSimulations = filterSet.getScenario() === null;
+    const isSimulationDimension = filterSet.getDimension() === "simulations";
+    const needsConstraints = isAllSimulations && !isSimulationDimension;
+
+    if (needsConstraints && self._results !== null) {
+      const firstScenario = self._results.getFirstScenario();
+      return filterSet.getWithScenario(firstScenario);
+    } else {
+      return filterSet;
+    }
   }
 
   /**


### PR DESCRIPTION
Constrain the filter set so that all simulations cannot be selected when reviewing applications and substances. This avoids a situation where the resulting graph, though valid, is hard to interpret.