### PR TITLE
Clarify initial charge to use in import supplement.

### DIFF
--- a/js/engine.js
+++ b/js/engine.js
@@ -417,8 +417,25 @@ class Engine {
     } else {
       const application = self._scope.getApplication();
       const substance = self._scope.getSubstance();
-      return self._streamKeeper.getInitialCharge(application, substance, stream);
+      return self.getRawInitialChargeFor(application, substance, stream);
     }
+  }
+
+  /**
+   * Get the initial charge for a specific application and substance.
+   *
+   * @param {string} application - The name of the application for which inital
+   *     charge is requested like commerical refrigeration.
+   * @param {string} substance - The name of the substance for which inital
+   *     charge is requested like HFC-134a.
+   * @param {string} stream - The stream in which the initial charge is
+   *     requested and must be realized (import or manufacturing).
+   * @returns {EngineNumber} The initial charge for the stream in the given
+   *     application and substance.
+   */
+  getRawInitialChargeFor(application, substance, stream) {
+    const self = this;
+    return self._streamKeeper.getInitialCharge(application, substance, stream);
   }
 
   /**

--- a/js/engine_serializer.js
+++ b/js/engine_serializer.js
@@ -184,6 +184,13 @@ class EngineResultSerializer {
     const ghgIntensity = self._engine.getEqualsGhgIntensityFor(application, substance);
     stateGetter.setSubstanceConsumption(ghgIntensity);
 
+    const importInitialChargeUnit = self._engine.getRawInitialChargeFor(
+      application,
+      substance,
+      "import",
+    );
+    stateGetter.setAmortizedUnitVolume(importInitialChargeUnit);
+
     // Determine import value without recharge
     const totalImportValue = self._engine.getStreamRaw(application, substance, "import");
     const totalDomesticValue = self._engine.getStreamRaw(application, substance, "manufacture");


### PR DESCRIPTION
Clarify that the import initial charge should be used in calculating the number of units for the import supplement.