### PR TITLE
Add live tests for retire to Java.

### DIFF
--- a/engine/src/test/java/org/kigalisim/validate/RetireLiveTests.java
+++ b/engine/src/test/java/org/kigalisim/validate/RetireLiveTests.java
@@ -1,0 +1,109 @@
+/**
+ * Retire live tests using actual QTA files.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.kigalisim.validate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.kigalisim.KigaliSimFacade;
+import org.kigalisim.engine.serializer.EngineResult;
+import org.kigalisim.lang.program.ParsedProgram;
+
+/**
+ * Tests that validate retire QTA files against expected behavior.
+ */
+public class RetireLiveTests {
+
+  /**
+   * Test retire.qta produces expected values.
+   */
+  @Test
+  public void testRetire() throws IOException {
+    // Load and parse the QTA file
+    String qtaPath = "../examples/retire.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    // Run the scenario using KigaliSimFacade
+    String scenarioName = "business as usual";
+    Stream<EngineResult> results = KigaliSimFacade.runScenarioWithResults(program, scenarioName);
+
+    List<EngineResult> resultsList = results.collect(Collectors.toList());
+    
+    // Check year 1 equipment (population) value
+    EngineResult resultYear1 = LiveTestsUtil.getResult(resultsList.stream(), 1, "test", "test");
+    assertNotNull(resultYear1, "Should have result for test/test in year 1");
+    assertEquals(100000.0, resultYear1.getPopulation().getValue().doubleValue(), 0.0001,
+        "Equipment should be 100000 units in year 1");
+    assertEquals("units", resultYear1.getPopulation().getUnits(),
+        "Equipment units should be units");
+    
+    // Check year 2 equipment (population) value
+    EngineResult resultYear2 = LiveTestsUtil.getResult(resultsList.stream(), 2, "test", "test");
+    assertNotNull(resultYear2, "Should have result for test/test in year 2");
+    assertEquals(190000.0, resultYear2.getPopulation().getValue().doubleValue(), 0.0001,
+        "Equipment should be 190000 units in year 2");
+    assertEquals("units", resultYear2.getPopulation().getUnits(),
+        "Equipment units should be units");
+  }
+
+  /**
+   * Test retire_prior.qta produces expected values.
+   */
+  @Test
+  public void testRetirePrior() throws IOException {
+    // Load and parse the QTA file
+    String qtaPath = "../examples/retire_prior.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    // Run the scenario using KigaliSimFacade
+    String scenarioName = "business as usual";
+    Stream<EngineResult> results = KigaliSimFacade.runScenarioWithResults(program, scenarioName);
+
+    List<EngineResult> resultsList = results.collect(Collectors.toList());
+    
+    // Check year 1 equipment (population) value
+    EngineResult resultYear1 = LiveTestsUtil.getResult(resultsList.stream(), 1, "test", "test");
+    assertNotNull(resultYear1, "Should have result for test/test in year 1");
+    assertEquals(190000.0, resultYear1.getPopulation().getValue().doubleValue(), 0.0001,
+        "Equipment should be 190000 units in year 1");
+    assertEquals("units", resultYear1.getPopulation().getUnits(),
+        "Equipment units should be units");
+  }
+
+  /**
+   * Test retire_multiple.qta produces expected values.
+   */
+  @Test
+  public void testRetireMultiple() throws IOException {
+    // Load and parse the QTA file
+    String qtaPath = "../examples/retire_multiple.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    // Run the scenario using KigaliSimFacade
+    String scenarioName = "business as usual";
+    Stream<EngineResult> results = KigaliSimFacade.runScenarioWithResults(program, scenarioName);
+
+    List<EngineResult> resultsList = results.collect(Collectors.toList());
+    
+    // Check year 1 equipment (population) value
+    EngineResult resultYear1 = LiveTestsUtil.getResult(resultsList.stream(), 1, "test", "test");
+    assertNotNull(resultYear1, "Should have result for test/test in year 1");
+    assertTrue(resultYear1.getPopulation().getValue().doubleValue() < 190000.0,
+        "Equipment should be less than 190000 units in year 1");
+    assertEquals("units", resultYear1.getPopulation().getUnits(),
+        "Equipment units should be units");
+  }
+}


### PR DESCRIPTION
Add live integration tests for scripts with retire in the Java version of the interpreter. Closes #276.