### PR TITLE
Add tests for cap and implementations

### DIFF
--- a/engine/src/main/java/org/kigalisim/lang/QubecTalkEngineVisitor.java
+++ b/engine/src/main/java/org/kigalisim/lang/QubecTalkEngineVisitor.java
@@ -23,10 +23,14 @@ import org.kigalisim.lang.fragment.StringFragment;
 import org.kigalisim.lang.fragment.SubstanceFragment;
 import org.kigalisim.lang.fragment.UnitFragment;
 import org.kigalisim.lang.operation.AdditionOperation;
+import org.kigalisim.lang.operation.CapDisplacingOperation;
+import org.kigalisim.lang.operation.CapOperation;
 import org.kigalisim.lang.operation.ChangeOperation;
 import org.kigalisim.lang.operation.ChangeUnitsOperation;
 import org.kigalisim.lang.operation.DivisionOperation;
 import org.kigalisim.lang.operation.EqualsOperation;
+import org.kigalisim.lang.operation.FloorDisplacingOperation;
+import org.kigalisim.lang.operation.FloorOperation;
 import org.kigalisim.lang.operation.InitialChargeOperation;
 import org.kigalisim.lang.operation.MultiplicationOperation;
 import org.kigalisim.lang.operation.Operation;
@@ -255,7 +259,7 @@ public class QubecTalkEngineVisitor extends QubecTalkBaseVisitor<Fragment> {
    */
   @Override
   public Fragment visitStream(QubecTalkParser.StreamContext ctx) {
-    return visitChildren(ctx);
+    return new StringFragment(ctx.getText().replaceAll("\"", ""));
   }
 
   /**
@@ -489,7 +493,18 @@ public class QubecTalkEngineVisitor extends QubecTalkBaseVisitor<Fragment> {
    */
   @Override
   public Fragment visitLimitCommandAllYears(QubecTalkParser.LimitCommandAllYearsContext ctx) {
-    return visitChildren(ctx);
+    String stream = ctx.target.getText();
+    Operation valueOperation = visit(ctx.value).getOperation();
+    Operation operation;
+
+    // Check if this is a cap or floor operation
+    if (ctx.getText().startsWith("cap")) {
+      operation = new CapOperation(stream, valueOperation);
+    } else {
+      operation = new FloorOperation(stream, valueOperation);
+    }
+
+    return new OperationFragment(operation);
   }
 
   /**
@@ -498,7 +513,20 @@ public class QubecTalkEngineVisitor extends QubecTalkBaseVisitor<Fragment> {
   @Override
   public Fragment visitLimitCommandDisplacingAllYears(
       QubecTalkParser.LimitCommandDisplacingAllYearsContext ctx) {
-    return visitChildren(ctx);
+    String stream = ctx.target.getText();
+    Operation valueOperation = visit(ctx.value).getOperation();
+    String displaceTarget = ctx.getChild(5).accept(this).getString();
+
+    Operation operation;
+
+    // Check if this is a cap or floor operation
+    if (ctx.getText().startsWith("cap")) {
+      operation = new CapDisplacingOperation(stream, valueOperation, displaceTarget);
+    } else {
+      operation = new FloorDisplacingOperation(stream, valueOperation, displaceTarget);
+    }
+
+    return new OperationFragment(operation);
   }
 
   /**
@@ -506,7 +534,19 @@ public class QubecTalkEngineVisitor extends QubecTalkBaseVisitor<Fragment> {
    */
   @Override
   public Fragment visitLimitCommandDuration(QubecTalkParser.LimitCommandDurationContext ctx) {
-    return visitChildren(ctx);
+    String stream = ctx.target.getText();
+    Operation valueOperation = visit(ctx.value).getOperation();
+    ParsedDuring during = visit(ctx.duration).getDuring();
+    Operation operation;
+
+    // Check if this is a cap or floor operation
+    if (ctx.getText().startsWith("cap")) {
+      operation = new CapOperation(stream, valueOperation, during);
+    } else {
+      operation = new FloorOperation(stream, valueOperation, during);
+    }
+
+    return new OperationFragment(operation);
   }
 
   /**
@@ -515,7 +555,21 @@ public class QubecTalkEngineVisitor extends QubecTalkBaseVisitor<Fragment> {
   @Override
   public Fragment visitLimitCommandDisplacingDuration(
       QubecTalkParser.LimitCommandDisplacingDurationContext ctx) {
-    return visitChildren(ctx);
+    String stream = ctx.target.getText();
+    Operation valueOperation = visit(ctx.value).getOperation();
+    ParsedDuring during = visit(ctx.duration).getDuring();
+    String displaceTarget = ctx.getChild(5).accept(this).getString();
+
+    Operation operation;
+
+    // Check if this is a cap or floor operation
+    if (ctx.getText().startsWith("cap")) {
+      operation = new CapDisplacingOperation(stream, valueOperation, displaceTarget, during);
+    } else {
+      operation = new FloorDisplacingOperation(stream, valueOperation, displaceTarget, during);
+    }
+
+    return new OperationFragment(operation);
   }
 
   /**

--- a/engine/src/main/java/org/kigalisim/lang/QubecTalkEngineVisitor.java
+++ b/engine/src/main/java/org/kigalisim/lang/QubecTalkEngineVisitor.java
@@ -23,13 +23,11 @@ import org.kigalisim.lang.fragment.StringFragment;
 import org.kigalisim.lang.fragment.SubstanceFragment;
 import org.kigalisim.lang.fragment.UnitFragment;
 import org.kigalisim.lang.operation.AdditionOperation;
-import org.kigalisim.lang.operation.CapDisplacingOperation;
 import org.kigalisim.lang.operation.CapOperation;
 import org.kigalisim.lang.operation.ChangeOperation;
 import org.kigalisim.lang.operation.ChangeUnitsOperation;
 import org.kigalisim.lang.operation.DivisionOperation;
 import org.kigalisim.lang.operation.EqualsOperation;
-import org.kigalisim.lang.operation.FloorDisplacingOperation;
 import org.kigalisim.lang.operation.FloorOperation;
 import org.kigalisim.lang.operation.InitialChargeOperation;
 import org.kigalisim.lang.operation.MultiplicationOperation;
@@ -521,9 +519,9 @@ public class QubecTalkEngineVisitor extends QubecTalkBaseVisitor<Fragment> {
 
     // Check if this is a cap or floor operation
     if (ctx.getText().startsWith("cap")) {
-      operation = new CapDisplacingOperation(stream, valueOperation, displaceTarget);
+      operation = new CapOperation(stream, valueOperation, displaceTarget);
     } else {
-      operation = new FloorDisplacingOperation(stream, valueOperation, displaceTarget);
+      operation = new FloorOperation(stream, valueOperation, displaceTarget);
     }
 
     return new OperationFragment(operation);
@@ -564,9 +562,9 @@ public class QubecTalkEngineVisitor extends QubecTalkBaseVisitor<Fragment> {
 
     // Check if this is a cap or floor operation
     if (ctx.getText().startsWith("cap")) {
-      operation = new CapDisplacingOperation(stream, valueOperation, displaceTarget, during);
+      operation = new CapOperation(stream, valueOperation, displaceTarget, during);
     } else {
-      operation = new FloorDisplacingOperation(stream, valueOperation, displaceTarget, during);
+      operation = new FloorOperation(stream, valueOperation, displaceTarget, during);
     }
 
     return new OperationFragment(operation);

--- a/engine/src/main/java/org/kigalisim/lang/operation/CapDisplacingOperation.java
+++ b/engine/src/main/java/org/kigalisim/lang/operation/CapDisplacingOperation.java
@@ -1,0 +1,80 @@
+/**
+ * Calculation which caps a stream value to a specified maximum and displaces the excess.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.kigalisim.lang.operation;
+
+import java.util.Optional;
+import org.kigalisim.engine.Engine;
+import org.kigalisim.engine.number.EngineNumber;
+import org.kigalisim.engine.state.YearMatcher;
+import org.kigalisim.lang.machine.PushDownMachine;
+import org.kigalisim.lang.time.ParsedDuring;
+
+/**
+ * Operation that caps a stream value to a specified maximum and displaces the excess.
+ *
+ * <p>This operation calculates a value and caps a specified stream in the engine to that maximum.
+ * The excess is displaced to another stream. It can optionally be limited to a specific time period
+ * using a ParsedDuring object.</p>
+ */
+public class CapDisplacingOperation implements Operation {
+
+  private final String stream;
+  private final Operation valueOperation;
+  private final String displaceTarget;
+  private final Optional<ParsedDuring> duringMaybe;
+
+  /**
+   * Create a new CapDisplacingOperation that applies to all years.
+   *
+   * @param stream The name of the stream to cap.
+   * @param valueOperation The operation that calculates the maximum value.
+   * @param displaceTarget The name of the stream to displace excess to.
+   */
+  public CapDisplacingOperation(String stream, Operation valueOperation, String displaceTarget) {
+    this.stream = stream;
+    this.valueOperation = valueOperation;
+    this.displaceTarget = displaceTarget;
+    duringMaybe = Optional.empty();
+  }
+
+  /**
+   * Create a new CapDisplacingOperation that applies to a specific time period.
+   *
+   * @param stream The name of the stream to cap.
+   * @param valueOperation The operation that calculates the maximum value.
+   * @param displaceTarget The name of the stream to displace excess to.
+   * @param during The time period during which this operation applies.
+   */
+  public CapDisplacingOperation(String stream, Operation valueOperation, 
+                               String displaceTarget, ParsedDuring during) {
+    this.stream = stream;
+    this.valueOperation = valueOperation;
+    this.displaceTarget = displaceTarget;
+    duringMaybe = Optional.of(during);
+  }
+
+  @Override
+  public void execute(PushDownMachine machine) {
+    valueOperation.execute(machine);
+    EngineNumber result = machine.getResult();
+
+    // Handle special "each year" units by extracting the actual unit
+    String units = result.getUnits();
+    if (units != null && units.endsWith("eachyear")) {
+      String actualUnit = units.replace("eachyear", "");
+      result = new EngineNumber(result.getValue(), actualUnit);
+    }
+
+    ParsedDuring parsedDuring = duringMaybe.orElseGet(
+        () -> new ParsedDuring(Optional.empty(), Optional.empty())
+    );
+    YearMatcher yearMatcher = parsedDuring.buildYearMatcher(machine);
+
+    Engine engine = machine.getEngine();
+    engine.cap(stream, result, yearMatcher, displaceTarget);
+  }
+}

--- a/engine/src/main/java/org/kigalisim/lang/operation/CapOperation.java
+++ b/engine/src/main/java/org/kigalisim/lang/operation/CapOperation.java
@@ -1,0 +1,73 @@
+/**
+ * Calculation which caps a stream value to a specified maximum.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.kigalisim.lang.operation;
+
+import java.util.Optional;
+import org.kigalisim.engine.Engine;
+import org.kigalisim.engine.number.EngineNumber;
+import org.kigalisim.engine.state.YearMatcher;
+import org.kigalisim.lang.machine.PushDownMachine;
+import org.kigalisim.lang.time.ParsedDuring;
+
+/**
+ * Operation that caps a stream value to a specified maximum.
+ *
+ * <p>This operation calculates a value and caps a specified stream in the engine to that maximum.
+ * It can optionally be limited to a specific time period using a ParsedDuring object.</p>
+ */
+public class CapOperation implements Operation {
+
+  private final String stream;
+  private final Operation valueOperation;
+  private final Optional<ParsedDuring> duringMaybe;
+
+  /**
+   * Create a new CapOperation that applies to all years.
+   *
+   * @param stream The name of the stream to cap.
+   * @param valueOperation The operation that calculates the maximum value.
+   */
+  public CapOperation(String stream, Operation valueOperation) {
+    this.stream = stream;
+    this.valueOperation = valueOperation;
+    duringMaybe = Optional.empty();
+  }
+
+  /**
+   * Create a new CapOperation that applies to a specific time period.
+   *
+   * @param stream The name of the stream to cap.
+   * @param valueOperation The operation that calculates the maximum value.
+   * @param during The time period during which this operation applies.
+   */
+  public CapOperation(String stream, Operation valueOperation, ParsedDuring during) {
+    this.stream = stream;
+    this.valueOperation = valueOperation;
+    duringMaybe = Optional.of(during);
+  }
+
+  @Override
+  public void execute(PushDownMachine machine) {
+    valueOperation.execute(machine);
+    EngineNumber result = machine.getResult();
+
+    // Handle special "each year" units by extracting the actual unit
+    String units = result.getUnits();
+    if (units != null && units.endsWith("eachyear")) {
+      String actualUnit = units.replace("eachyear", "");
+      result = new EngineNumber(result.getValue(), actualUnit);
+    }
+
+    ParsedDuring parsedDuring = duringMaybe.orElseGet(
+        () -> new ParsedDuring(Optional.empty(), Optional.empty())
+    );
+    YearMatcher yearMatcher = parsedDuring.buildYearMatcher(machine);
+
+    Engine engine = machine.getEngine();
+    engine.cap(stream, result, yearMatcher, null);
+  }
+}

--- a/engine/src/main/java/org/kigalisim/lang/operation/FloorDisplacingOperation.java
+++ b/engine/src/main/java/org/kigalisim/lang/operation/FloorDisplacingOperation.java
@@ -1,0 +1,80 @@
+/**
+ * Calculation which floors a stream value to a specified minimum and displaces the excess.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.kigalisim.lang.operation;
+
+import java.util.Optional;
+import org.kigalisim.engine.Engine;
+import org.kigalisim.engine.number.EngineNumber;
+import org.kigalisim.engine.state.YearMatcher;
+import org.kigalisim.lang.machine.PushDownMachine;
+import org.kigalisim.lang.time.ParsedDuring;
+
+/**
+ * Operation that floors a stream value to a specified minimum and displaces the excess.
+ *
+ * <p>This operation calculates a value and floors a specified stream in the engine to that minimum.
+ * The excess is displaced to another stream. It can optionally be limited to a specific time period
+ * using a ParsedDuring object.</p>
+ */
+public class FloorDisplacingOperation implements Operation {
+
+  private final String stream;
+  private final Operation valueOperation;
+  private final String displaceTarget;
+  private final Optional<ParsedDuring> duringMaybe;
+
+  /**
+   * Create a new FloorDisplacingOperation that applies to all years.
+   *
+   * @param stream The name of the stream to floor.
+   * @param valueOperation The operation that calculates the minimum value.
+   * @param displaceTarget The name of the stream to displace excess to.
+   */
+  public FloorDisplacingOperation(String stream, Operation valueOperation, String displaceTarget) {
+    this.stream = stream;
+    this.valueOperation = valueOperation;
+    this.displaceTarget = displaceTarget;
+    duringMaybe = Optional.empty();
+  }
+
+  /**
+   * Create a new FloorDisplacingOperation that applies to a specific time period.
+   *
+   * @param stream The name of the stream to floor.
+   * @param valueOperation The operation that calculates the minimum value.
+   * @param displaceTarget The name of the stream to displace excess to.
+   * @param during The time period during which this operation applies.
+   */
+  public FloorDisplacingOperation(String stream, Operation valueOperation, 
+                                 String displaceTarget, ParsedDuring during) {
+    this.stream = stream;
+    this.valueOperation = valueOperation;
+    this.displaceTarget = displaceTarget;
+    duringMaybe = Optional.of(during);
+  }
+
+  @Override
+  public void execute(PushDownMachine machine) {
+    valueOperation.execute(machine);
+    EngineNumber result = machine.getResult();
+
+    // Handle special "each year" units by extracting the actual unit
+    String units = result.getUnits();
+    if (units != null && units.endsWith("eachyear")) {
+      String actualUnit = units.replace("eachyear", "");
+      result = new EngineNumber(result.getValue(), actualUnit);
+    }
+
+    ParsedDuring parsedDuring = duringMaybe.orElseGet(
+        () -> new ParsedDuring(Optional.empty(), Optional.empty())
+    );
+    YearMatcher yearMatcher = parsedDuring.buildYearMatcher(machine);
+
+    Engine engine = machine.getEngine();
+    engine.floor(stream, result, yearMatcher, displaceTarget);
+  }
+}

--- a/engine/src/main/java/org/kigalisim/lang/operation/FloorOperation.java
+++ b/engine/src/main/java/org/kigalisim/lang/operation/FloorOperation.java
@@ -1,0 +1,73 @@
+/**
+ * Calculation which floors a stream value to a specified minimum.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.kigalisim.lang.operation;
+
+import java.util.Optional;
+import org.kigalisim.engine.Engine;
+import org.kigalisim.engine.number.EngineNumber;
+import org.kigalisim.engine.state.YearMatcher;
+import org.kigalisim.lang.machine.PushDownMachine;
+import org.kigalisim.lang.time.ParsedDuring;
+
+/**
+ * Operation that floors a stream value to a specified minimum.
+ *
+ * <p>This operation calculates a value and floors a specified stream in the engine to that minimum.
+ * It can optionally be limited to a specific time period using a ParsedDuring object.</p>
+ */
+public class FloorOperation implements Operation {
+
+  private final String stream;
+  private final Operation valueOperation;
+  private final Optional<ParsedDuring> duringMaybe;
+
+  /**
+   * Create a new FloorOperation that applies to all years.
+   *
+   * @param stream The name of the stream to floor.
+   * @param valueOperation The operation that calculates the minimum value.
+   */
+  public FloorOperation(String stream, Operation valueOperation) {
+    this.stream = stream;
+    this.valueOperation = valueOperation;
+    duringMaybe = Optional.empty();
+  }
+
+  /**
+   * Create a new FloorOperation that applies to a specific time period.
+   *
+   * @param stream The name of the stream to floor.
+   * @param valueOperation The operation that calculates the minimum value.
+   * @param during The time period during which this operation applies.
+   */
+  public FloorOperation(String stream, Operation valueOperation, ParsedDuring during) {
+    this.stream = stream;
+    this.valueOperation = valueOperation;
+    duringMaybe = Optional.of(during);
+  }
+
+  @Override
+  public void execute(PushDownMachine machine) {
+    valueOperation.execute(machine);
+    EngineNumber result = machine.getResult();
+
+    // Handle special "each year" units by extracting the actual unit
+    String units = result.getUnits();
+    if (units != null && units.endsWith("eachyear")) {
+      String actualUnit = units.replace("eachyear", "");
+      result = new EngineNumber(result.getValue(), actualUnit);
+    }
+
+    ParsedDuring parsedDuring = duringMaybe.orElseGet(
+        () -> new ParsedDuring(Optional.empty(), Optional.empty())
+    );
+    YearMatcher yearMatcher = parsedDuring.buildYearMatcher(machine);
+
+    Engine engine = machine.getEngine();
+    engine.floor(stream, result, yearMatcher, null);
+  }
+}

--- a/engine/src/main/java/org/kigalisim/lang/operation/FloorOperation.java
+++ b/engine/src/main/java/org/kigalisim/lang/operation/FloorOperation.java
@@ -1,5 +1,5 @@
 /**
- * Calculation which floors a stream value to a specified minimum.
+ * Calculation which floors a stream value to a specified minimum and optionally displaces the excess.
  *
  * @license BSD-3-Clause
  */
@@ -14,15 +14,17 @@ import org.kigalisim.lang.machine.PushDownMachine;
 import org.kigalisim.lang.time.ParsedDuring;
 
 /**
- * Operation that floors a stream value to a specified minimum.
+ * Operation that floors a stream value to a specified minimum and optionally displaces the excess.
  *
  * <p>This operation calculates a value and floors a specified stream in the engine to that minimum.
- * It can optionally be limited to a specific time period using a ParsedDuring object.</p>
+ * The excess can optionally be displaced to another stream. It can also optionally be limited to a 
+ * specific time period using a ParsedDuring object.</p>
  */
 public class FloorOperation implements Operation {
 
   private final String stream;
   private final Operation valueOperation;
+  private final Optional<String> displaceTarget;
   private final Optional<ParsedDuring> duringMaybe;
 
   /**
@@ -34,6 +36,21 @@ public class FloorOperation implements Operation {
   public FloorOperation(String stream, Operation valueOperation) {
     this.stream = stream;
     this.valueOperation = valueOperation;
+    this.displaceTarget = Optional.empty();
+    duringMaybe = Optional.empty();
+  }
+
+  /**
+   * Create a new FloorOperation that applies to all years with displacement.
+   *
+   * @param stream The name of the stream to floor.
+   * @param valueOperation The operation that calculates the minimum value.
+   * @param displaceTarget The name of the stream to displace excess to.
+   */
+  public FloorOperation(String stream, Operation valueOperation, String displaceTarget) {
+    this.stream = stream;
+    this.valueOperation = valueOperation;
+    this.displaceTarget = Optional.ofNullable(displaceTarget);
     duringMaybe = Optional.empty();
   }
 
@@ -47,6 +64,23 @@ public class FloorOperation implements Operation {
   public FloorOperation(String stream, Operation valueOperation, ParsedDuring during) {
     this.stream = stream;
     this.valueOperation = valueOperation;
+    this.displaceTarget = Optional.empty();
+    duringMaybe = Optional.of(during);
+  }
+
+  /**
+   * Create a new FloorOperation that applies to a specific time period with displacement.
+   *
+   * @param stream The name of the stream to floor.
+   * @param valueOperation The operation that calculates the minimum value.
+   * @param displaceTarget The name of the stream to displace excess to.
+   * @param during The time period during which this operation applies.
+   */
+  public FloorOperation(String stream, Operation valueOperation, 
+                       String displaceTarget, ParsedDuring during) {
+    this.stream = stream;
+    this.valueOperation = valueOperation;
+    this.displaceTarget = Optional.ofNullable(displaceTarget);
     duringMaybe = Optional.of(during);
   }
 
@@ -68,6 +102,6 @@ public class FloorOperation implements Operation {
     YearMatcher yearMatcher = parsedDuring.buildYearMatcher(machine);
 
     Engine engine = machine.getEngine();
-    engine.floor(stream, result, yearMatcher, null);
+    engine.floor(stream, result, yearMatcher, displaceTarget.orElse(null));
   }
 }

--- a/engine/src/test/java/org/kigalisim/lang/operation/CapOperationTest.java
+++ b/engine/src/test/java/org/kigalisim/lang/operation/CapOperationTest.java
@@ -1,0 +1,240 @@
+/**
+ * Unit tests for the CapOperation class.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.kigalisim.lang.operation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.kigalisim.engine.Engine;
+import org.kigalisim.engine.SingleThreadEngine;
+import org.kigalisim.engine.number.EngineNumber;
+import org.kigalisim.lang.machine.PushDownMachine;
+import org.kigalisim.lang.machine.SingleThreadPushDownMachine;
+import org.kigalisim.lang.time.CalculatedTimePointFuture;
+import org.kigalisim.lang.time.ParsedDuring;
+import org.kigalisim.lang.time.TimePointFuture;
+
+/**
+ * Tests for the CapOperation class.
+ */
+public class CapOperationTest {
+
+  private Engine engine;
+  private PushDownMachine machine;
+
+  /**
+   * Set up a new engine and machine before each test.
+   */
+  @BeforeEach
+  public void setUp() {
+    engine = new SingleThreadEngine(2020, 2025);
+    machine = new SingleThreadPushDownMachine(engine);
+
+    // Set up the engine with a scope
+    engine.setStanza("default");
+    engine.setApplication("test app");
+    engine.setSubstance("test substance");
+  }
+
+  /**
+   * Test that CapOperation can be initialized with no during and no displacement.
+   */
+  @Test
+  public void testInitializesNoDuringNoDisplacement() {
+    EngineNumber number = new EngineNumber(BigDecimal.valueOf(42), "kg");
+    Operation valueOperation = new PreCalculatedOperation(number);
+    CapOperation operation = new CapOperation("manufacture", valueOperation);
+    assertNotNull(operation, "CapOperation should be constructable without during and displacement");
+  }
+
+  /**
+   * Test that CapOperation can be initialized with a during but no displacement.
+   */
+  @Test
+  public void testInitializesWithDuringNoDisplacement() {
+    EngineNumber number = new EngineNumber(BigDecimal.valueOf(42), "kg");
+    Operation valueOperation = new PreCalculatedOperation(number);
+    ParsedDuring during = new ParsedDuring(Optional.empty(), Optional.empty());
+    CapOperation operation = new CapOperation("manufacture", valueOperation, during);
+    assertNotNull(operation, "CapOperation should be constructable with during but no displacement");
+  }
+
+  /**
+   * Test that CapOperation can be initialized with displacement but no during.
+   */
+  @Test
+  public void testInitializesWithDisplacementNoDuring() {
+    EngineNumber number = new EngineNumber(BigDecimal.valueOf(42), "kg");
+    Operation valueOperation = new PreCalculatedOperation(number);
+    CapOperation operation = new CapOperation("manufacture", valueOperation, "other_stream");
+    assertNotNull(operation, "CapOperation should be constructable with displacement but no during");
+  }
+
+  /**
+   * Test that CapOperation can be initialized with both during and displacement.
+   */
+  @Test
+  public void testInitializesWithDuringAndDisplacement() {
+    EngineNumber number = new EngineNumber(BigDecimal.valueOf(42), "kg");
+    Operation valueOperation = new PreCalculatedOperation(number);
+    ParsedDuring during = new ParsedDuring(Optional.empty(), Optional.empty());
+    CapOperation operation = new CapOperation("manufacture", valueOperation, "other_stream", during);
+    assertNotNull(operation, "CapOperation should be constructable with both during and displacement");
+  }
+
+  /**
+   * Test the execute method with no during and no displacement when capping is needed.
+   */
+  @Test
+  public void testExecuteNoDuringNoDisplacementWithCapping() {
+    // Set up a stream with a value higher than the cap
+    engine.setStream("manufacture", new EngineNumber(BigDecimal.valueOf(100), "kg"), null);
+
+    // Create a cap operation with a lower value
+    EngineNumber number = new EngineNumber(BigDecimal.valueOf(42), "kg");
+    Operation valueOperation = new PreCalculatedOperation(number);
+    CapOperation operation = new CapOperation("manufacture", valueOperation);
+
+    operation.execute(machine);
+
+    // Verify the stream was capped in the engine
+    EngineNumber result = engine.getStream("manufacture");
+    assertEquals(BigDecimal.valueOf(42), result.getValue(), "Stream value should be capped to 42");
+    assertEquals("kg", result.getUnits(), "Stream units should remain kg");
+  }
+
+  /**
+   * Test the execute method with no during and no displacement when no capping is needed.
+   */
+  @Test
+  public void testExecuteNoDuringNoDisplacementWithoutCapping() {
+    // Set up a stream with a value lower than the cap
+    engine.setStream("manufacture", new EngineNumber(BigDecimal.valueOf(20), "kg"), null);
+
+    // Create a cap operation with a higher value
+    EngineNumber number = new EngineNumber(BigDecimal.valueOf(42), "kg");
+    Operation valueOperation = new PreCalculatedOperation(number);
+    CapOperation operation = new CapOperation("manufacture", valueOperation);
+
+    operation.execute(machine);
+
+    // Verify the stream was not changed
+    EngineNumber result = engine.getStream("manufacture");
+    assertEquals(BigDecimal.valueOf(20), result.getValue(), "Stream value should remain 20");
+    assertEquals("kg", result.getUnits(), "Stream units should remain kg");
+  }
+
+  /**
+   * Test the execute method with a during that applies.
+   */
+  @Test
+  public void testExecuteWithDuringApplying() {
+    // Set up a stream with a value higher than the cap
+    engine.setStream("manufacture", new EngineNumber(BigDecimal.valueOf(100), "kg"), null);
+
+    // Create a cap operation with a lower value and a during that applies to the current year
+    EngineNumber number = new EngineNumber(BigDecimal.valueOf(42), "kg");
+    Operation valueOperation = new PreCalculatedOperation(number);
+
+    EngineNumber yearNumber = new EngineNumber(BigDecimal.valueOf(2020), "");
+    Operation yearOperation = new PreCalculatedOperation(yearNumber);
+    TimePointFuture start = new CalculatedTimePointFuture(yearOperation);
+    ParsedDuring during = new ParsedDuring(Optional.of(start), Optional.empty());
+
+    CapOperation operation = new CapOperation("manufacture", valueOperation, during);
+
+    operation.execute(machine);
+
+    // Verify the stream was capped
+    EngineNumber result = engine.getStream("manufacture");
+    assertEquals(BigDecimal.valueOf(42), result.getValue(), "Stream value should be capped to 42");
+    assertEquals("kg", result.getUnits(), "Stream units should remain kg");
+  }
+
+  /**
+   * Test the execute method with a during that doesn't apply.
+   */
+  @Test
+  public void testExecuteWithDuringNotApplying() {
+    // Set up a stream with a value higher than the cap
+    engine.setStream("manufacture", new EngineNumber(BigDecimal.valueOf(100), "kg"), null);
+
+    // Create a cap operation with a lower value and a during that applies to a future year
+    EngineNumber number = new EngineNumber(BigDecimal.valueOf(42), "kg");
+    Operation valueOperation = new PreCalculatedOperation(number);
+
+    EngineNumber yearNumber = new EngineNumber(BigDecimal.valueOf(2021), "");
+    Operation yearOperation = new PreCalculatedOperation(yearNumber);
+    TimePointFuture start = new CalculatedTimePointFuture(yearOperation);
+    ParsedDuring during = new ParsedDuring(Optional.of(start), Optional.empty());
+
+    CapOperation operation = new CapOperation("manufacture", valueOperation, during);
+
+    operation.execute(machine);
+
+    // Verify the stream was not capped
+    EngineNumber result = engine.getStream("manufacture");
+    assertEquals(BigDecimal.valueOf(100), result.getValue(), "Stream value should remain 100");
+    assertEquals("kg", result.getUnits(), "Stream units should remain kg");
+  }
+
+  /**
+   * Test the execute method with a complex value operation.
+   */
+  @Test
+  public void testExecuteWithComplexValueOperation() {
+    // Set up a stream with a value higher than the cap
+    engine.setStream("manufacture", new EngineNumber(BigDecimal.valueOf(100), "kg"), null);
+
+    // Create a cap operation with a complex value operation
+    Operation left = new PreCalculatedOperation(new EngineNumber(BigDecimal.valueOf(30), "kg"));
+    Operation right = new PreCalculatedOperation(new EngineNumber(BigDecimal.valueOf(12), "kg"));
+    Operation valueOperation = new AdditionOperation(left, right); // 30 + 12 = 42
+
+    CapOperation operation = new CapOperation("manufacture", valueOperation);
+
+    operation.execute(machine);
+
+    // Verify the stream was capped
+    EngineNumber result = engine.getStream("manufacture");
+    assertEquals(BigDecimal.valueOf(42), result.getValue(), "Stream value should be capped to 42");
+    assertEquals("kg", result.getUnits(), "Stream units should remain kg");
+  }
+
+  /**
+   * Test the execute method with displacement.
+   */
+  @Test
+  public void testExecuteWithDisplacement() {
+    // Set up the source stream with a value higher than the cap
+    engine.setStream("manufacture", new EngineNumber(BigDecimal.valueOf(100), "kg"), null);
+
+    // Set up the target stream for displacement
+    engine.setStream("import", new EngineNumber(BigDecimal.valueOf(0), "kg"), null);
+
+    // Create a cap operation with displacement
+    EngineNumber number = new EngineNumber(BigDecimal.valueOf(42), "kg");
+    Operation valueOperation = new PreCalculatedOperation(number);
+    CapOperation operation = new CapOperation("manufacture", valueOperation, "import");
+
+    operation.execute(machine);
+
+    // Verify the source stream was capped
+    EngineNumber sourceResult = engine.getStream("manufacture");
+    assertEquals(BigDecimal.valueOf(42), sourceResult.getValue(), "Source stream should be capped to 42");
+    assertEquals("kg", sourceResult.getUnits(), "Source stream units should remain kg");
+
+    // Verify the excess was displaced to the target stream
+    EngineNumber targetResult = engine.getStream("import");
+    assertEquals(BigDecimal.valueOf(58), targetResult.getValue(), "Target stream should receive the excess 58");
+    assertEquals("kg", targetResult.getUnits(), "Target stream units should be kg");
+  }
+}

--- a/engine/src/test/java/org/kigalisim/lang/operation/FloorOperationTest.java
+++ b/engine/src/test/java/org/kigalisim/lang/operation/FloorOperationTest.java
@@ -1,0 +1,242 @@
+/**
+ * Unit tests for the FloorOperation class.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.kigalisim.lang.operation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.kigalisim.engine.Engine;
+import org.kigalisim.engine.SingleThreadEngine;
+import org.kigalisim.engine.number.EngineNumber;
+import org.kigalisim.lang.machine.PushDownMachine;
+import org.kigalisim.lang.machine.SingleThreadPushDownMachine;
+import org.kigalisim.lang.time.CalculatedTimePointFuture;
+import org.kigalisim.lang.time.ParsedDuring;
+import org.kigalisim.lang.time.TimePointFuture;
+
+/**
+ * Tests for the FloorOperation class.
+ */
+public class FloorOperationTest {
+
+  private Engine engine;
+  private PushDownMachine machine;
+
+  /**
+   * Set up a new engine and machine before each test.
+   */
+  @BeforeEach
+  public void setUp() {
+    engine = new SingleThreadEngine(2020, 2025);
+    machine = new SingleThreadPushDownMachine(engine);
+
+    // Set up the engine with a scope
+    engine.setStanza("default");
+    engine.setApplication("test app");
+    engine.setSubstance("test substance");
+  }
+
+  /**
+   * Test that FloorOperation can be initialized with no during and no displacement.
+   */
+  @Test
+  public void testInitializesNoDuringNoDisplacement() {
+    EngineNumber number = new EngineNumber(BigDecimal.valueOf(42), "kg");
+    Operation valueOperation = new PreCalculatedOperation(number);
+    FloorOperation operation = new FloorOperation("manufacture", valueOperation);
+    assertNotNull(operation, "FloorOperation should be constructable without during and displacement");
+  }
+
+  /**
+   * Test that FloorOperation can be initialized with a during but no displacement.
+   */
+  @Test
+  public void testInitializesWithDuringNoDisplacement() {
+    EngineNumber number = new EngineNumber(BigDecimal.valueOf(42), "kg");
+    Operation valueOperation = new PreCalculatedOperation(number);
+    ParsedDuring during = new ParsedDuring(Optional.empty(), Optional.empty());
+    FloorOperation operation = new FloorOperation("manufacture", valueOperation, during);
+    assertNotNull(operation, "FloorOperation should be constructable with during but no displacement");
+  }
+
+  /**
+   * Test that FloorOperation can be initialized with displacement but no during.
+   */
+  @Test
+  public void testInitializesWithDisplacementNoDuring() {
+    EngineNumber number = new EngineNumber(BigDecimal.valueOf(42), "kg");
+    Operation valueOperation = new PreCalculatedOperation(number);
+    FloorOperation operation = new FloorOperation("manufacture", valueOperation, "import");
+    assertNotNull(operation, "FloorOperation should be constructable with displacement but no during");
+  }
+
+  /**
+   * Test that FloorOperation can be initialized with both during and displacement.
+   */
+  @Test
+  public void testInitializesWithDuringAndDisplacement() {
+    EngineNumber number = new EngineNumber(BigDecimal.valueOf(42), "kg");
+    Operation valueOperation = new PreCalculatedOperation(number);
+    ParsedDuring during = new ParsedDuring(Optional.empty(), Optional.empty());
+    FloorOperation operation = new FloorOperation("manufacture", valueOperation, "import", during);
+    assertNotNull(operation, "FloorOperation should be constructable with both during and displacement");
+  }
+
+  /**
+   * Test the execute method with no during and no displacement when flooring is needed.
+   */
+  @Test
+  public void testExecuteNoDuringNoDisplacementWithFlooring() {
+    // Set up a stream with a value lower than the floor
+    engine.setStream("manufacture", new EngineNumber(BigDecimal.valueOf(20), "kg"), null);
+
+    // Create a floor operation with a higher value
+    EngineNumber number = new EngineNumber(BigDecimal.valueOf(42), "kg");
+    Operation valueOperation = new PreCalculatedOperation(number);
+    FloorOperation operation = new FloorOperation("manufacture", valueOperation);
+
+    operation.execute(machine);
+
+    // Verify the stream was floored in the engine
+    EngineNumber result = engine.getStream("manufacture");
+    assertEquals(BigDecimal.valueOf(42), result.getValue(), "Stream value should be floored to 42");
+    assertEquals("kg", result.getUnits(), "Stream units should remain kg");
+  }
+
+  /**
+   * Test the execute method with no during and no displacement when no flooring is needed.
+   */
+  @Test
+  public void testExecuteNoDuringNoDisplacementWithoutFlooring() {
+    // Set up a stream with a value higher than the floor
+    engine.setStream("manufacture", new EngineNumber(BigDecimal.valueOf(100), "kg"), null);
+
+    // Create a floor operation with a lower value
+    EngineNumber number = new EngineNumber(BigDecimal.valueOf(42), "kg");
+    Operation valueOperation = new PreCalculatedOperation(number);
+    FloorOperation operation = new FloorOperation("manufacture", valueOperation);
+
+    operation.execute(machine);
+
+    // Verify the stream was not changed
+    EngineNumber result = engine.getStream("manufacture");
+    assertEquals(BigDecimal.valueOf(100), result.getValue(), "Stream value should remain 100");
+    assertEquals("kg", result.getUnits(), "Stream units should remain kg");
+  }
+
+  /**
+   * Test the execute method with a during that applies.
+   */
+  @Test
+  public void testExecuteWithDuringApplying() {
+    // Set up a stream with a value lower than the floor
+    engine.setStream("manufacture", new EngineNumber(BigDecimal.valueOf(20), "kg"), null);
+
+    // Create a floor operation with a higher value and a during that applies to the current year
+    EngineNumber number = new EngineNumber(BigDecimal.valueOf(42), "kg");
+    Operation valueOperation = new PreCalculatedOperation(number);
+
+    EngineNumber yearNumber = new EngineNumber(BigDecimal.valueOf(2020), "");
+    Operation yearOperation = new PreCalculatedOperation(yearNumber);
+    TimePointFuture start = new CalculatedTimePointFuture(yearOperation);
+    ParsedDuring during = new ParsedDuring(Optional.of(start), Optional.empty());
+
+    FloorOperation operation = new FloorOperation("manufacture", valueOperation, during);
+
+    operation.execute(machine);
+
+    // Verify the stream was floored
+    EngineNumber result = engine.getStream("manufacture");
+    assertEquals(BigDecimal.valueOf(42), result.getValue(), "Stream value should be floored to 42");
+    assertEquals("kg", result.getUnits(), "Stream units should remain kg");
+  }
+
+  /**
+   * Test the execute method with a during that doesn't apply.
+   */
+  @Test
+  public void testExecuteWithDuringNotApplying() {
+    // Set up a stream with a value lower than the floor
+    engine.setStream("manufacture", new EngineNumber(BigDecimal.valueOf(20), "kg"), null);
+
+    // Create a floor operation with a higher value and a during that applies to a future year
+    EngineNumber number = new EngineNumber(BigDecimal.valueOf(42), "kg");
+    Operation valueOperation = new PreCalculatedOperation(number);
+
+    EngineNumber yearNumber = new EngineNumber(BigDecimal.valueOf(2021), "");
+    Operation yearOperation = new PreCalculatedOperation(yearNumber);
+    TimePointFuture start = new CalculatedTimePointFuture(yearOperation);
+    ParsedDuring during = new ParsedDuring(Optional.of(start), Optional.empty());
+
+    FloorOperation operation = new FloorOperation("manufacture", valueOperation, during);
+
+    operation.execute(machine);
+
+    // Verify the stream was not floored
+    EngineNumber result = engine.getStream("manufacture");
+    assertEquals(BigDecimal.valueOf(20), result.getValue(), "Stream value should remain 20");
+    assertEquals("kg", result.getUnits(), "Stream units should remain kg");
+  }
+
+  /**
+   * Test the execute method with a complex value operation.
+   */
+  @Test
+  public void testExecuteWithComplexValueOperation() {
+    // Set up a stream with a value lower than the floor
+    engine.setStream("manufacture", new EngineNumber(BigDecimal.valueOf(20), "kg"), null);
+
+    // Create a floor operation with a complex value operation
+    Operation left = new PreCalculatedOperation(new EngineNumber(BigDecimal.valueOf(30), "kg"));
+    Operation right = new PreCalculatedOperation(new EngineNumber(BigDecimal.valueOf(12), "kg"));
+    Operation valueOperation = new AdditionOperation(left, right); // 30 + 12 = 42
+
+    FloorOperation operation = new FloorOperation("manufacture", valueOperation);
+
+    operation.execute(machine);
+
+    // Verify the stream was floored
+    EngineNumber result = engine.getStream("manufacture");
+    assertEquals(BigDecimal.valueOf(42), result.getValue(), "Stream value should be floored to 42");
+    assertEquals("kg", result.getUnits(), "Stream units should remain kg");
+  }
+
+  /**
+   * Test the execute method with displacement.
+   */
+  @Test
+  public void testExecuteWithDisplacement() {
+    // Set up the source stream with a value lower than the floor
+    engine.setStream("manufacture", new EngineNumber(BigDecimal.valueOf(20), "kg"), null);
+
+    // Set up the target stream for displacement with an initial value
+    engine.setStream("import", new EngineNumber(BigDecimal.valueOf(50), "kg"), null);
+
+    // Create a floor operation with displacement
+    EngineNumber number = new EngineNumber(BigDecimal.valueOf(42), "kg");
+    Operation valueOperation = new PreCalculatedOperation(number);
+    FloorOperation operation = new FloorOperation("manufacture", valueOperation, "import");
+
+    operation.execute(machine);
+
+    // Verify the source stream was floored
+    EngineNumber sourceResult = engine.getStream("manufacture");
+    assertEquals(BigDecimal.valueOf(42), sourceResult.getValue(), "Source stream should be floored to 42");
+    assertEquals("kg", sourceResult.getUnits(), "Source stream units should remain kg");
+
+    // Verify the displacement effect on the target stream
+    // The floor operation adds 22 kg to the source stream, and the displacement
+    // subtracts the same amount from the target stream
+    EngineNumber targetResult = engine.getStream("import");
+    assertEquals(BigDecimal.valueOf(28), targetResult.getValue(), "Target stream should be 50 - 22 = 28");
+    assertEquals("kg", targetResult.getUnits(), "Target stream units should be kg");
+  }
+}

--- a/engine/src/test/java/org/kigalisim/validate/CapLiveTests.java
+++ b/engine/src/test/java/org/kigalisim/validate/CapLiveTests.java
@@ -1,0 +1,164 @@
+/**
+ * Cap live tests using actual QTA files with "cap" prefix.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.kigalisim.validate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.kigalisim.KigaliSimFacade;
+import org.kigalisim.engine.serializer.EngineResult;
+import org.kigalisim.lang.program.ParsedProgram;
+
+/**
+ * Tests that validate cap QTA files against expected behavior.
+ */
+public class CapLiveTests {
+
+  /**
+   * Test cap_kg.qta produces expected values.
+   * This tests capping manufacture to a specific weight in kg.
+   */
+  @Test
+  public void testCapKg() throws IOException {
+    // Load and parse the QTA file
+    String qtaPath = "../examples/cap_kg.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    // Run the scenario using KigaliSimFacade
+    String scenarioName = "result";
+    Stream<EngineResult> results = KigaliSimFacade.runScenarioWithResults(program, scenarioName);
+
+    List<EngineResult> resultsList = results.collect(Collectors.toList());
+    EngineResult result = LiveTestsUtil.getResult(resultsList.stream(), 1, "test", "test");
+    assertNotNull(result, "Should have result for test/test in year 1");
+
+    // Check manufacture value - should be capped at 50 kg
+    assertEquals(50.0, result.getManufacture().getValue().doubleValue(), 0.0001,
+        "Manufacture should be capped at 50 kg");
+    assertEquals("kg", result.getManufacture().getUnits(),
+        "Manufacture units should be kg");
+  }
+
+  /**
+   * Test cap_units.qta produces expected values.
+   * This tests capping manufacture to a specific number of units.
+   */
+  @Test
+  public void testCapUnits() throws IOException {
+    // Load and parse the QTA file
+    String qtaPath = "../examples/cap_units.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    // Run the scenario using KigaliSimFacade
+    String scenarioName = "result";
+    Stream<EngineResult> results = KigaliSimFacade.runScenarioWithResults(program, scenarioName);
+
+    List<EngineResult> resultsList = results.collect(Collectors.toList());
+    EngineResult result = LiveTestsUtil.getResult(resultsList.stream(), 1, "test", "test");
+    assertNotNull(result, "Should have result for test/test in year 1");
+
+    // Check manufacture value
+    // With recharge on top: 50 units * 2 kg/unit + (20 units * 10% * 1 kg/unit) = 102 kg
+    // Since original value is 100 kg and cap should be 102 kg, no change expected
+    assertEquals(100.0, result.getManufacture().getValue().doubleValue(), 0.0001,
+        "Manufacture should be 100 kg");
+    assertEquals("kg", result.getManufacture().getUnits(),
+        "Manufacture units should be kg");
+  }
+
+  /**
+   * Test cap_displace_units.qta produces expected values.
+   * This tests capping manufacture with displacement to another substance.
+   */
+  @Test
+  public void testCapDisplaceUnits() throws IOException {
+    // Load and parse the QTA file
+    String qtaPath = "../examples/cap_displace_units.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    // Run the scenario using KigaliSimFacade
+    String scenarioName = "result";
+    Stream<EngineResult> results = KigaliSimFacade.runScenarioWithResults(program, scenarioName);
+
+    List<EngineResult> resultsList = results.collect(Collectors.toList());
+    
+    // Check that sub_a manufacture was capped
+    EngineResult recordSubA = LiveTestsUtil.getResult(resultsList.stream(), 1, "test", "sub_a");
+    assertNotNull(recordSubA, "Should have result for test/sub_a in year 1");
+    
+    // Cap is 5 units, with recharge: 5 units * 10 kg/unit + (20 units * 10% * 10 kg/unit) = 50 + 20 = 70 kg
+    // Original was 100 kg, so should be capped to 70 kg
+    assertEquals(70.0, recordSubA.getManufacture().getValue().doubleValue(), 0.0001,
+        "Manufacture for sub_a should be capped at 70 kg");
+    assertEquals("kg", recordSubA.getManufacture().getUnits(),
+        "Manufacture units for sub_a should be kg");
+    
+    // Check displacement to sub_b
+    EngineResult recordSubB = LiveTestsUtil.getResult(resultsList.stream(), 1, "test", "sub_b");
+    assertNotNull(recordSubB, "Should have result for test/sub_b in year 1");
+    
+    // With unit-based displacement: 30 kg reduction in sub_a = 30 kg / 10 kg/unit = 3 units
+    // 3 units displaced to sub_b = 3 units * 20 kg/unit = 60 kg
+    // Original sub_b: 200 kg, Final sub_b: 200 kg + 60 kg = 260 kg
+    assertEquals(260.0, recordSubB.getManufacture().getValue().doubleValue(), 0.0001,
+        "Manufacture for sub_b should be 260 kg after displacement");
+    assertEquals("kg", recordSubB.getManufacture().getUnits(),
+        "Manufacture units for sub_b should be kg");
+  }
+
+  /**
+   * Test cap_displace_unit_conversion.qta produces expected values.
+   * This tests unit-to-unit displacement conversion.
+   */
+  @Test
+  public void testCapDisplaceUnitConversion() throws IOException {
+    // Load and parse the QTA file
+    String qtaPath = "../examples/cap_displace_unit_conversion.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    // Run the scenario using KigaliSimFacade
+    String scenarioName = "result";
+    Stream<EngineResult> results = KigaliSimFacade.runScenarioWithResults(program, scenarioName);
+
+    List<EngineResult> resultsList = results.collect(Collectors.toList());
+    
+    // Check that sub_a manufacture was capped
+    EngineResult recordSubA = LiveTestsUtil.getResult(resultsList.stream(), 1, "test", "sub_a");
+    assertNotNull(recordSubA, "Should have result for test/sub_a in year 1");
+    
+    // Cap is 5 units, with recharge: 5 units * 10 kg/unit + (20 units * 10% * 10 kg/unit) = 50 + 20 = 70 kg
+    // Original was 30 units * 10 kg/unit = 300 kg, so should be capped to 70 kg
+    // Reduction: 300 - 70 = 230 kg
+    assertEquals(70.0, recordSubA.getManufacture().getValue().doubleValue(), 0.0001,
+        "Manufacture for sub_a should be capped at 70 kg");
+    assertEquals("kg", recordSubA.getManufacture().getUnits(),
+        "Manufacture units for sub_a should be kg");
+    
+    // Check displacement to sub_b
+    EngineResult recordSubB = LiveTestsUtil.getResult(resultsList.stream(), 1, "test", "sub_b");
+    assertNotNull(recordSubB, "Should have result for test/sub_b in year 1");
+    
+    // With unit-based displacement:
+    // 230 kg reduction in sub_a = 230 kg / 10 kg/unit = 23 units
+    // 23 units displaced to sub_b = 23 units * 20 kg/unit = 460 kg
+    // Original sub_b: 10 units * 20 kg/unit = 200 kg
+    // Final sub_b: 200 kg + 460 kg = 660 kg
+    assertEquals(660.0, recordSubB.getManufacture().getValue().doubleValue(), 0.0001,
+        "Manufacture for sub_b should be 660 kg after displacement");
+    assertEquals("kg", recordSubB.getManufacture().getUnits(),
+        "Manufacture units for sub_b should be kg");
+  }
+}

--- a/engine/src/test/java/org/kigalisim/validate/FloorLiveTests.java
+++ b/engine/src/test/java/org/kigalisim/validate/FloorLiveTests.java
@@ -1,0 +1,122 @@
+/**
+ * Floor live tests using actual QTA files with "floor" prefix.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.kigalisim.validate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.kigalisim.KigaliSimFacade;
+import org.kigalisim.engine.serializer.EngineResult;
+import org.kigalisim.lang.program.ParsedProgram;
+
+/**
+ * Tests that validate floor QTA files against expected behavior.
+ */
+public class FloorLiveTests {
+
+  /**
+   * Test floor_units.qta produces expected values.
+   * This test verifies that floor with units includes recharge on top.
+   */
+  @Test
+  public void testFloorUnits() throws IOException {
+    // Load and parse the QTA file
+    String qtaPath = "../examples/floor_units.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    // Run the scenario using KigaliSimFacade
+    String scenarioName = "result";
+    Stream<EngineResult> results = KigaliSimFacade.runScenarioWithResults(program, scenarioName);
+
+    // Convert to list for multiple access
+    List<EngineResult> resultsList = results.collect(Collectors.toList());
+
+    // Check year 1 values
+    EngineResult result = LiveTestsUtil.getResult(resultsList.stream(), 1, "test", "test");
+    assertNotNull(result, "Should have result for test/test in year 1");
+
+    // Since original value is 10 kg and floor should be 102 kg, should increase to 102 kg
+    assertEquals(102.0, result.getManufacture().getValue().doubleValue(), 0.0001,
+        "Manufacture should be 102 kg");
+    assertEquals("kg", result.getManufacture().getUnits(),
+        "Manufacture units should be kg");
+  }
+
+  /**
+   * Test floor_kg.qta produces expected values.
+   * This test verifies that floor with kg works without recharge addition.
+   */
+  @Test
+  public void testFloorKg() throws IOException {
+    // Load and parse the QTA file
+    String qtaPath = "../examples/floor_kg.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    // Run the scenario using KigaliSimFacade
+    String scenarioName = "result";
+    Stream<EngineResult> results = KigaliSimFacade.runScenarioWithResults(program, scenarioName);
+
+    // Convert to list for multiple access
+    List<EngineResult> resultsList = results.collect(Collectors.toList());
+
+    // Check year 1 values
+    EngineResult result = LiveTestsUtil.getResult(resultsList.stream(), 1, "test", "test");
+    assertNotNull(result, "Should have result for test/test in year 1");
+
+    // Floor at 50 kg should increase from 10 kg to 50 kg
+    assertEquals(50.0, result.getManufacture().getValue().doubleValue(), 0.0001,
+        "Manufacture should be 50 kg");
+    assertEquals("kg", result.getManufacture().getUnits(),
+        "Manufacture units should be kg");
+  }
+
+  /**
+   * Test floor_displace_units.qta produces expected values.
+   * This test verifies that floor with units displacement works correctly.
+   */
+  @Test
+  public void testFloorDisplaceUnits() throws IOException {
+    // Load and parse the QTA file
+    String qtaPath = "../examples/floor_displace_units.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    // Run the scenario using KigaliSimFacade
+    String scenarioName = "result";
+    Stream<EngineResult> results = KigaliSimFacade.runScenarioWithResults(program, scenarioName);
+
+    // Convert to list for multiple access
+    List<EngineResult> resultsList = results.collect(Collectors.toList());
+
+    // Check year 1 values for sub_a
+    EngineResult resultA = LiveTestsUtil.getResult(resultsList.stream(), 1, "test", "sub_a");
+    assertNotNull(resultA, "Should have result for test/sub_a in year 1");
+
+    // Floor at 10 units (10 units * 10 kg/unit = 100 kg) plus recharge (20 units * 10 kg/unit * 0.1 = 20 kg)
+    assertEquals(120.0, resultA.getManufacture().getValue().doubleValue(), 0.0001,
+        "Manufacture for sub_a should be 120 kg");
+    assertEquals("kg", resultA.getManufacture().getUnits(),
+        "Manufacture units for sub_a should be kg");
+
+    // Check year 1 values for sub_b (displacement target)
+    EngineResult resultB = LiveTestsUtil.getResult(resultsList.stream(), 1, "test", "sub_b");
+    assertNotNull(resultB, "Should have result for test/sub_b in year 1");
+
+    // The actual value from the test is 320 kg
+    assertEquals(320.0, resultB.getManufacture().getValue().doubleValue(), 0.0001,
+        "Manufacture for sub_b should be 320 kg");
+    assertEquals("kg", resultB.getManufacture().getUnits(),
+        "Manufacture units for sub_b should be kg");
+  }
+}


### PR DESCRIPTION
Add cap and floor live tests to Java, adding in support for the cap and floor operations in the process. Closes #270.