### PR TITLE
Centralize the creation of the CSV string in Java.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -9,7 +9,7 @@ import {ReportDataWrapper} from "report_data";
 import {ResultsPresenter} from "results";
 import {UiEditorPresenter} from "ui_editor";
 import {UiTranslatorCompiler} from "ui_translator";
-import {WasmBackend, WasmLayer} from "wasm_backend";
+import {WasmBackend, WasmLayer, BackendResult} from "wasm_backend";
 
 const HELP_TEXT = "Would you like our help in resolving this issue?";
 
@@ -344,7 +344,7 @@ class MainPresenter {
           // Hide the running indicator when execution completes
           self._hideRunningIndicator();
 
-          if (programResult.length === 0) {
+          if (programResult.getParsedResults().length === 0) {
             self._showNoResultsMessage();
           } else {
             if (resetFilters) {
@@ -403,10 +403,10 @@ class MainPresenter {
   /**
    * Handles program execution results and displays them.
    *
-   * @param {Object} results - The results of program execution.
+   * @param {BackendResult} backendResult - The backend result containing CSV and parsed data.
    * @private
    */
-  _onResult(results) {
+  _onResult(backendResult) {
     const self = this;
 
     // Hide any existing no-results message and error indicator
@@ -416,8 +416,8 @@ class MainPresenter {
     }
     self._hideErrorIndicator();
 
-    const resultsWrapped = new ReportDataWrapper(results);
-    self._resultsPresenter.showResults(resultsWrapped);
+    const resultsWrapped = new ReportDataWrapper(backendResult.getParsedResults());
+    self._resultsPresenter.showResults(resultsWrapped, backendResult);
   }
 
   /**

--- a/js/results.js
+++ b/js/results.js
@@ -129,11 +129,13 @@ class ResultsPresenter {
    * Show simulation results.
    *
    * @param {ReportDataWrapper} results - Results data to display.
+   * @param {BackendResult} backendResult - Backend result containing CSV string.
    */
-  showResults(results) {
+  showResults(results, backendResult) {
     const self = this;
     self._root.style.display = "block";
     self._results = results;
+    self._backendResult = backendResult;
     self._updateInternally();
   }
 
@@ -221,7 +223,7 @@ class ResultsPresenter {
     self._dimensionPresenter.showResults(self._results, self._filterSet);
     self._centerChartPresenter.showResults(self._results, self._filterSet);
     self._titlePreseter.showResults(self._results, self._filterSet);
-    self._exportPresenter.showResults(self._results, self._filterSet);
+    self._exportPresenter.showResults(self._results, self._filterSet, self._backendResult);
     self._optionsPresenter.showResults(self._results, self._filterSet);
   }
 }
@@ -245,86 +247,13 @@ class ExportPresenter {
    *
    * @param {Object} results - Results data to export.
    * @param {FilterSet} filterSet - Current filter settings.
+   * @param {BackendResult} backendResult - Backend result containing CSV string.
    */
-  showResults(results, filterSet) {
+  showResults(results, filterSet, backendResult) {
     const self = this;
-    const rawData = results.getRawData(filterSet);
-    const flat = rawData.map((result) => {
-      const scenarioName = result.getScenarioName();
-      const application = result.getApplication();
-      const substance = result.getSubstance();
-      const year = result.getYear();
-      const manufactureValue = result.getManufacture();
-      const importValue = result.getImport();
-      const rechargeEmissionsValue = result.getRechargeEmissions();
-      const eolEmissionsValue = result.getEolEmissions();
-      const populationValue = result.getPopulation();
-      const energyConsumptionValue = result.getEnergyConsumption();
-      return {
-        scenario: scenarioName,
-        application: application,
-        substance: substance,
-        year: year,
-        manufactureValue: manufactureValue.getValue(),
-        manufactureUnits: manufactureValue.getUnits(),
-        importValue: importValue.getValue(),
-        importUnits: importValue.getUnits(),
-        rechargeEmissionsValue: rechargeEmissionsValue.getValue(),
-        rechargeEmissionsUnits: rechargeEmissionsValue.getUnits(),
-        eolEmissionsValue: eolEmissionsValue.getValue(),
-        eolEmissionsUnits: eolEmissionsValue.getUnits(),
-        equipmentPopulation: populationValue.getValue(),
-        equipmentUnits: populationValue.getUnits(),
-        energyConsumptionValue: energyConsumptionValue.getValue(),
-        energyConsumptionUnits: energyConsumptionValue.getUnits(),
-      };
-    });
-    const contentRows = flat.map((record) => {
-      const vals = [
-        record["scenario"],
-        record["application"],
-        record["substance"],
-        record["year"],
-        record["manufactureValue"],
-        record["manufactureUnits"],
-        record["importValue"],
-        record["importUnits"],
-        record["rechargeEmissionsValue"],
-        record["rechargeEmissionsUnits"],
-        record["eolEmissionsValue"],
-        record["eolEmissionsUnits"],
-        record["equipmentPopulation"],
-        record["equipmentUnits"],
-        record["energyConsumptionValue"],
-        record["energyConsumptionUnits"],
-      ];
-      const valsStrs = vals.map((x) => x + "");
-      const valsStr = valsStrs.join(",");
-      return valsStr;
-    });
-    const contentStr = contentRows.join("\n");
 
-    const headerElements = [
-      "scenario",
-      "application",
-      "substance",
-      "year",
-      "manufactureValue",
-      "manufactureUnits",
-      "importValue",
-      "importUnits",
-      "rechargeEmissionsValue",
-      "rechargeEmisionsUnits",
-      "eolEmissionsValue",
-      "eolEmisionsUnits",
-      "equipmentPopulation",
-      "equipmentUnits",
-      "energyConsumptionValue",
-      "energyConsumptionUnits",
-    ];
-    const headerStr = headerElements.join(",");
-
-    const csvStr = headerStr + "\n" + contentStr;
+    // Use the CSV string directly from the backend instead of generating our own
+    const csvStr = backendResult.getCsvString();
     const encodedValue = encodeURI("data:text/csv;charset=utf-8," + csvStr);
     const exportLink = document.getElementById("export-button");
     exportLink.href = encodedValue;

--- a/test/test_integration.js
+++ b/test/test_integration.js
@@ -29,7 +29,8 @@ function buildIntegrationTests() {
           assert.ok(content.length > 0);
 
           try {
-            const programResult = await wasmBackend.execute(content);
+            const backendResult = await wasmBackend.execute(content);
+            const programResult = backendResult.getParsedResults();
             checks.forEach((check) => {
               check(programResult, assert);
             });

--- a/test/test_report_data.js
+++ b/test/test_report_data.js
@@ -20,7 +20,8 @@ function buildReportDataTests() {
 
           try {
             // Execute using WASM backend instead of old JS engine
-            const programResult = await wasmBackend.execute(content);
+            const backendResult = await wasmBackend.execute(content);
+            const programResult = backendResult.getParsedResults();
             const programResultWrapped = new ReportDataWrapper(programResult);
             checks.forEach((check) => {
               check(programResultWrapped, assert);

--- a/test/test_wasm_backend.js
+++ b/test/test_wasm_backend.js
@@ -4,7 +4,7 @@
  * @license BSD, see LICENSE.md.
  */
 
-import {WasmBackend, WasmLayer, ReportDataParser} from "wasm_backend";
+import {WasmBackend, WasmLayer, ReportDataParser, BackendResult} from "wasm_backend";
 import {EngineNumber} from "engine_number";
 import {EngineResult, ImportSupplement} from "engine_struct";
 
@@ -277,8 +277,11 @@ function buildWasmBackendTests() {
 
             mockWorker.onmessage({data: responseData});
 
-            runPromise.then((results) => {
-              assert.ok(Array.isArray(results), "Should return array of results");
+            runPromise.then((backendResult) => {
+              assert.ok(backendResult instanceof BackendResult,
+                "Should return BackendResult instance");
+              assert.ok(Array.isArray(backendResult.getParsedResults()),
+                "Should contain array of parsed results");
               // Restore original Worker
               window.Worker = originalWorker;
               done();


### PR DESCRIPTION
Closes #367. Centralize the creation of the CSV string so the work is not repeated in JS.