### PR TITLE
Format with replacement checkbox

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -737,7 +737,7 @@
                             <div>
                               <label><strong>Change equipment count through retirement</strong></label>
                             </div>
-                            <div>
+                            <div class="checkbox-list">
                               <label>
                                 <input
                                   type="checkbox"


### PR DESCRIPTION
Do not have the "Retirement reduces in-service equipment." be bold by default.