### PR TITLE
Add normal and uniform sampling options for QTA users. (#604)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -165,6 +165,45 @@ jobs:
           echo "SUCCESS: CSV file was created and is non-empty"
           echo "CSV file contents:"
           cat /tmp/minimal_interpreter.csv
+  runMonteCarloReplicates:
+    needs: [ checkEngine, testEngine, runEngineLocal ]
+    environment: Build
+    runs-on: ubuntu-latest
+    name: Run Monte Carlo Replicates Test
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./engine
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Download fat jar
+        uses: actions/download-artifact@v4
+        with:
+          name: fatJar
+          path: engine/build/libs/
+      - name: Run Monte Carlo simulation with 100 replicates and normal distribution
+        run: java -jar build/libs/kigalisim-fat.jar run ../examples/test_monte_carlo_replicates.qta -o /tmp/monte_carlo_replicates.csv -r 100
+      - name: Check CSV file was created and is non-empty
+        run: |
+          if [ ! -f /tmp/monte_carlo_replicates.csv ]; then
+            echo "ERROR: CSV file was not created"
+            exit 1
+          fi
+          if [ ! -s /tmp/monte_carlo_replicates.csv ]; then
+            echo "ERROR: CSV file is empty"
+            exit 1
+          fi
+          echo "SUCCESS: CSV file was created and is non-empty"
+          echo "Number of lines in CSV:"
+          wc -l /tmp/monte_carlo_replicates.csv
+          echo "First 10 lines of CSV file:"
+          head -10 /tmp/monte_carlo_replicates.csv
   buildWasm:
     environment: Build
     needs: [ checkEngine, buildEngine, testEngine, runEngineLocal ]
@@ -234,7 +273,7 @@ jobs:
     environment: build
     runs-on: ubuntu-latest
     name: Deploy Prep
-    needs: [ lintJs, unitTestsBrowser, checkCacheBusters, buildWasm ]
+    needs: [ lintJs, unitTestsBrowser, checkCacheBusters, buildWasm, runMonteCarloReplicates ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/beta_changelog.md
+++ b/beta_changelog.md
@@ -14,6 +14,14 @@ Finally, we want to again express our gratitude for your feedback and time.
 
 The following changes have been adopted and released.
 
+### Trial sampling options
+
+**Status**: Released October 22, 2025
+
+**Classification**: Bug
+
+In follow up to Monte Carlo features recently released, fixed the normal and uniform distribution sampling. Our sincere apologies for this issue. See [#604](https://github.com/SchmidtDSE/kigali-sim/pull/604).
+
 ### Servicing in policy UI
 
 **Status**: Released October 21, 2025
@@ -21,6 +29,14 @@ The following changes have been adopted and released.
 **Classification**: Enhancement
 
 Allow the user to include servicing into a policy. In other words, allows UI-based editor to express changes to servicing schedule previuosly only possible in QubecTalk code. See [#600](https://github.com/SchmidtDSE/kigali-sim/pull/600).
+
+### Parallel Monte Carlo
+
+**Status**: Released October 20, 2025
+
+**Classification**: Enghancement
+
+Added support for parallelized Monte Carlo for those running simulations from the Jar. See [#594](https://github.com/SchmidtDSE/kigali-sim/pull/594).
 
 ### Multiple retire / recharge
 

--- a/engine/src/main/java/org/kigalisim/lang/QubecTalkEngineVisitor.java
+++ b/engine/src/main/java/org/kigalisim/lang/QubecTalkEngineVisitor.java
@@ -33,6 +33,8 @@ import org.kigalisim.lang.operation.ChangeUnitsOperation;
 import org.kigalisim.lang.operation.ConditionalOperation;
 import org.kigalisim.lang.operation.DefineVariableOperation;
 import org.kigalisim.lang.operation.DivisionOperation;
+import org.kigalisim.lang.operation.DrawNormalOperation;
+import org.kigalisim.lang.operation.DrawUniformOperation;
 import org.kigalisim.lang.operation.EnableOperation;
 import org.kigalisim.lang.operation.EqualityOperation;
 import org.kigalisim.lang.operation.EqualsOperation;
@@ -246,7 +248,14 @@ public class QubecTalkEngineVisitor extends QubecTalkBaseVisitor<Fragment> {
    */
   @Override
   public Fragment visitDrawNormalExpression(QubecTalkParser.DrawNormalExpressionContext ctx) {
-    return visitChildren(ctx);
+    Fragment meanFragment = visit(ctx.mean);
+    Operation mean = meanFragment.getOperation();
+
+    Fragment stdFragment = visit(ctx.std);
+    Operation std = stdFragment.getOperation();
+
+    Operation operation = new DrawNormalOperation(mean, std);
+    return new OperationFragment(operation);
   }
 
   /**
@@ -278,7 +287,14 @@ public class QubecTalkEngineVisitor extends QubecTalkBaseVisitor<Fragment> {
    */
   @Override
   public Fragment visitDrawUniformExpression(QubecTalkParser.DrawUniformExpressionContext ctx) {
-    return visitChildren(ctx);
+    Fragment lowFragment = visit(ctx.low);
+    Operation low = lowFragment.getOperation();
+
+    Fragment highFragment = visit(ctx.high);
+    Operation high = highFragment.getOperation();
+
+    Operation operation = new DrawUniformOperation(low, high);
+    return new OperationFragment(operation);
   }
 
   /**

--- a/engine/src/main/java/org/kigalisim/lang/machine/PushDownMachine.java
+++ b/engine/src/main/java/org/kigalisim/lang/machine/PushDownMachine.java
@@ -177,4 +177,23 @@ public interface PushDownMachine {
    * operand is right below.</p>
    */
   void lessThanOrEqual();
+
+  /**
+   * Draw a random number from a normal distribution.
+   *
+   * <p>Draw a random number from a normal distribution using the two numbers on top of the stack
+   * as the mean and standard deviation. The right operand (top of stack) is the standard deviation
+   * and the left operand (next on stack) is the mean. Pushes the sampled value to the top of the
+   * stack.</p>
+   */
+  void drawNormal();
+
+  /**
+   * Draw a random number from a uniform distribution.
+   *
+   * <p>Draw a random number from a uniform distribution using the two numbers on top of the stack
+   * as the low and high bounds. The right operand (top of stack) is the high bound and the left
+   * operand (next on stack) is the low bound. Pushes the sampled value to the top of the stack.</p>
+   */
+  void drawUniform();
 }

--- a/engine/src/main/java/org/kigalisim/lang/operation/DrawNormalOperation.java
+++ b/engine/src/main/java/org/kigalisim/lang/operation/DrawNormalOperation.java
@@ -1,0 +1,40 @@
+/**
+ * Calculation which draws a random sample from a normal distribution.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.kigalisim.lang.operation;
+
+import org.kigalisim.lang.machine.PushDownMachine;
+
+/**
+ * Calculation that samples from a normal distribution.
+ *
+ * <p>Calculation that resolves two calculations (mean and standard deviation) and then draws a
+ * random sample from a normal distribution with those parameters by using a PushDownMachine within
+ * the QubecTalk runtime.</p>
+ */
+public class DrawNormalOperation implements Operation {
+
+  private final Operation mean;
+  private final Operation std;
+
+  /**
+   * Create a new DrawNormalOperation.
+   *
+   * @param mean The mean of the normal distribution.
+   * @param std The standard deviation of the normal distribution.
+   */
+  public DrawNormalOperation(Operation mean, Operation std) {
+    this.mean = mean;
+    this.std = std;
+  }
+
+  @Override
+  public void execute(PushDownMachine machine) {
+    mean.execute(machine);
+    std.execute(machine);
+    machine.drawNormal();
+  }
+}

--- a/engine/src/main/java/org/kigalisim/lang/operation/DrawUniformOperation.java
+++ b/engine/src/main/java/org/kigalisim/lang/operation/DrawUniformOperation.java
@@ -1,0 +1,40 @@
+/**
+ * Calculation which draws a random sample from a uniform distribution.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.kigalisim.lang.operation;
+
+import org.kigalisim.lang.machine.PushDownMachine;
+
+/**
+ * Calculation that samples from a uniform distribution.
+ *
+ * <p>Calculation that resolves two calculations (low and high bounds) and then draws a random
+ * sample from a uniform distribution within those bounds by using a PushDownMachine within the
+ * QubecTalk runtime.</p>
+ */
+public class DrawUniformOperation implements Operation {
+
+  private final Operation low;
+  private final Operation high;
+
+  /**
+   * Create a new DrawUniformOperation.
+   *
+   * @param low The lower bound of the uniform distribution.
+   * @param high The upper bound of the uniform distribution.
+   */
+  public DrawUniformOperation(Operation low, Operation high) {
+    this.low = low;
+    this.high = high;
+  }
+
+  @Override
+  public void execute(PushDownMachine machine) {
+    low.execute(machine);
+    high.execute(machine);
+    machine.drawUniform();
+  }
+}

--- a/examples/test_monte_carlo_replicates.qta
+++ b/examples/test_monte_carlo_replicates.qta
@@ -1,0 +1,94 @@
+start about
+  # Name: "Monte Carlo Replicates Test"
+  # Description: "Test simulation with 100 trials using normal distributions for CI"
+  # Author: "KigaliSim Test Suite"
+end about
+
+start default
+
+  define application "domestic refrigeration"
+
+    uses substance "HFC-134a"
+      enable domestic
+      enable import
+      initial charge with 0.12 kg / unit for domestic
+      initial charge with 0.15 kg / unit for import
+
+      # Use normal distribution for domestic manufacturing with uncertainty
+      set domestic to sample normally from mean of 50000 std of 5000 kg during year 1
+      change domestic by sample normally from mean of 5 std of 1 % each year during years 2 to 10
+
+      # Use normal distribution for imports with uncertainty
+      set import to sample normally from mean of 30000 std of 3000 kg during year 1
+      change import by sample normally from mean of 4 std of 1 % each year during years 2 to 10
+
+      equals 1430 kgCO2e / kg
+      equals 100 kwh / unit
+
+      retire 6.7 % each year
+      recharge 10 % with 0.12 kg / unit
+    end substance
+
+    uses substance "R-600a"
+      enable domestic
+      initial charge with 0.05 kg / unit for domestic
+
+      # Natural refrigerant with lower GWP
+      equals 6 tCO2e / mt
+      equals 95 kwh / unit
+    end substance
+
+  end application
+
+  define application "domestic air conditioning"
+
+    uses substance "R-410A"
+      enable domestic
+      enable import
+      initial charge with 1.5 kg / unit for domestic
+      initial charge with 1.8 kg / unit for import
+
+      # Use uniform distribution for AC equipment to test both sampling methods
+      set domestic to sample uniformly from 18000 to 22000 kg during year 1
+      change domestic by sample uniformly from 5 to 7 % each year during years 2 to 10
+
+      set import to sample uniformly from 13500 to 16500 kg during year 1
+      change import by sample uniformly from 4 to 6 % each year during years 2 to 10
+
+      equals 2088 kgCO2e / kg
+      equals 1200 kwh / unit
+
+      retire 8 % each year
+      recharge 12 % with 1.5 kg / unit
+    end substance
+
+  end application
+
+end default
+
+start policy "HFC Phasedown"
+  modify application "domestic refrigeration"
+    modify substance "HFC-134a"
+      cap domestic to 85 % during years 3 to 5
+      cap import to 85 % during years 3 to 5
+      recover 20 % with 80 % reuse at eol during years 4 to 10
+      replace 50 % of domestic with "R-600a" during years 6 to 10
+    end substance
+  end application
+
+  modify application "domestic air conditioning"
+    modify substance "R-410A"
+      cap domestic to 80 % during years 4 to 7
+      cap import to 80 % during years 4 to 7
+      recover 15 % with 75 % reuse at eol during years 5 to 10
+    end substance
+  end application
+end policy
+
+start simulations
+
+  simulate "business as usual" from years 1 to 10 across 100 trials
+
+  simulate "with phasedown" using "HFC Phasedown" from years 1 to 10 across 100 trials
+
+end simulations


### PR DESCRIPTION
* Add normal and uniform sampling options for QTA users.

* Update beta changelog with new features and fixes

Added entries for trial sampling options and parallel Monte Carlo enhancements in the changelog.

* Fixes on #604.

* Rearrange actions slightly.