### PR TITLE
Add colon to substance name normalization in GWP lookup

### DIFF
--- a/editor/js/known_substance.js
+++ b/editor/js/known_substance.js
@@ -79,7 +79,7 @@ class SubstanceLibraryKeeper {
 
   /**
    * Normalizes substance names for flexible matching.
-   * Converts to lowercase and removes whitespace and punctuation including hyphens.
+   * Converts to lowercase and removes whitespace and punctuation including hyphens and colons.
    *
    * @param {string} name - The substance name to normalize.
    * @returns {string} The normalized key for lookup.
@@ -87,7 +87,7 @@ class SubstanceLibraryKeeper {
    */
   _getSubstanceKey(name) {
     const self = this;
-    return name.toLowerCase().replace(/[\s\-_\.,\(\)\[\]]/g, "");
+    return name.toLowerCase().replace(/[\s\-_\.,:\(\)\[\]]/g, "");
   }
 }
 

--- a/editor/test/test_known_substance.js
+++ b/editor/test/test_known_substance.js
@@ -105,6 +105,7 @@ function buildKnownSubstanceTests() {
         "R_407C",
         "R(407)C",
         "R[407]C",
+        "R:407C",
         " R - 407 C ",
       ];
 


### PR DESCRIPTION
Extended the substance name normalization regex to also remove colons (:) when matching substance names. This allows for more flexible matching when users enter substance names with colons.

Changes:
- Updated _getSubstanceKey regex to include colon in removed characters
- Added test case "R:407C" to verify colon normalization works correctly
- Updated JSDoc comment to mention colons

🤖 Generated with [Claude Code](https://claude.com/claude-code)