### PR TITLE
Fix styling on default sales assumption.

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -522,16 +522,18 @@
                           <div class="form-group">
                             <div><label for="sales-assumption">Default sales assumption in a new year:</label></div>
                             <div>
-                              <select
-                                name="sales-assumption"
-                                class="sales-assumption-input mid"
-                                aria-label="Default sales assumption for new years"
-                                data-tippy-content="Controls how sales carry over from one year to the next. 'Continue from last year' maintains existing sales patterns (default). 'Cover only servicing' limits sales to recharge needs only. 'Go back to zero' resets all sales."
-                              >
-                                <option value="continued">Continue from last year (recommended)</option>
-                                <option value="only recharge">Cover only servicing</option>
-                                <option value="no">Go back to zero</option>
-                              </select>
+                              <span class="sel long">
+                                <select
+                                  name="sales-assumption"
+                                  class="sales-assumption-input"
+                                  aria-label="Default sales assumption for new years"
+                                  data-tippy-content="Controls how sales carry over from one year to the next. 'Continue from last year' maintains existing sales patterns (default). 'Cover only servicing' limits sales to recharge needs only. 'Go back to zero' resets all sales."
+                                >
+                                  <option value="continued">Continue from last year (recommended)</option>
+                                  <option value="only recharge">Cover only servicing</option>
+                                  <option value="no">Go back to zero</option>
+                                </select>
+                              </span>
                             </div>
                           </div>
                         </div>


### PR DESCRIPTION
Match the styling of "Default sales assumption in a new year:" dropdown to the "Application:" dropdown by wrapping it in a span.sel.long container and removing the mid class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)