### PR TITLE
Update equipment retirement label text

### DIFF
--- a/docs/guide/md/tutorial_02.md
+++ b/docs/guide/md/tutorial_02.md
@@ -47,6 +47,8 @@ Now let's define the equipment characteristics that drive HFC consumption:
 - Set annual retirement rate to **5% each year** (corresponds to 20-year average equipment lifetime)
 - Leave **"Retirement reduces in-service equipment"** checked (recommended for most simulations)
 
+The retirement rate is sometimes called the **hazard rate** or **scrap rate** in equipment lifecycle analysis. Kigali Sim, by default, assumes a constant hazard rate when you specify a percentage. However, this can be modified by using a non-percentage retirement amount if you need more complex retirement patterns.
+
 These basic parameters are enough to start modeling, but we also will want to account for servicing existing equipment.
 
 (tutorial02_step03.gif - alt: animated gif showing how to specify equipment properties)

--- a/docs/guide/tutorial_02.html
+++ b/docs/guide/tutorial_02.html
@@ -102,6 +102,8 @@
           <li>Leave <strong>"Retirement reduces in-service equipment"</strong> checked (recommended for most simulations)</li>
         </ul>
 
+        <p>The retirement rate is sometimes called the <strong>hazard rate</strong> or <strong>scrap rate</strong> in equipment lifecycle analysis. Kigali Sim, by default, assumes a constant hazard rate when you specify a percentage. However, this can be modified by using a non-percentage retirement amount if you need more complex retirement patterns.</p>
+
         <p>These basic parameters are enough to start modeling, but we also will want to account for servicing existing equipment.</p>
 
         <p id="tutorial-gif-2-3" class="tutorial-gif-holder">

--- a/editor/index.html
+++ b/editor/index.html
@@ -527,7 +527,7 @@
                                   name="sales-assumption"
                                   class="sales-assumption-input"
                                   aria-label="Default sales assumption for new years"
-                                  data-tippy-content="Baseline sales to assume if a specific level is not specified. 'Continue from last year' starts sales at the prior year's level (default). 'Cover only servicing' starts sales at recharge needs only. 'Go back to zero' starts sales at zero."
+                                  data-tippy-content="Sales to assume if a specific level is not specified. 'Continue from last year' starts sales at the prior year's level (default). 'Cover only servicing' starts sales at recharge needs only. 'Go back to zero' starts sales at zero."
                                 >
                                   <option value="continued">Continue from last year (recommended)</option>
                                   <option value="only recharge">Cover only servicing</option>
@@ -707,7 +707,7 @@
                           <div class="form-group">
                             <div>
                               <label for="edit-consumption-retirement"
-                                >Amount of equipment retired annually:</label
+                                >Amount of equipment retired annually (hazard / scrap rate):</label
                               >
                             </div>
                             <div>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -63,7 +63,7 @@ The about stanza is optional.
 - `change {stream} by {amount} <during>` - Growth or decay rates where amount is often +X %
 
 #### Equipment Lifecycle
-- `retire {amount} <with replacement> <during>` - Equipment retirement rate (with replacement maintains equipment population)
+- `retire {amount} <with replacement> <during>` - Equipment retirement rate, also called hazard rate or scrap rate (with replacement maintains equipment population)
 - `recharge {population} with {volume} <during>` - Service recharging (population = equipment to recharge, volume = substance per unit)
 - `set priorEquipment to {amount} <during>` - Pre-existing equipment.
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -63,7 +63,7 @@ As diverse methodologies measure stocks, Kigali Sim provides automated unit conv
 Leaving the following for future work, Kigali Sim:
 
  - Can model energy consumption but only estimates direct emissions^[Users may combine exported data with energy mix information for indirect emissions [@energy_mix].].
- - Asks users to provide retirement and servicing as amortized rates as modelers typically do not know the specific age distribution of equipment, similar to IPCC Tier 1 [@ipcc_tiers].
+ - Asks users to provide retirement and servicing as amortized hazard / retirement rates as modelers typically do not know the specific age distribution of equipment, similar to IPCC Tier 1 [@ipcc_tiers].
  - Provides automatic lookup but allows for override with country-specific parameters, similar to IPCC Tier 2 [@ipcc_tiers].
  - Applies treaty trade attribution but will only attribute charge prior to equipment sale entirely to either the importer or exporter^[Local assembly can be modeled as domestic production.].
 


### PR DESCRIPTION
- Update editor label to clarify retirement as hazard/scrap rate
- Add hazard/scrap rate terminology to QubecTalk documentation
- Add explanatory text to Tutorial 2 about retirement terminology
- Update paper limitations to reference amortized hazard/retirement rates
- Change "Baseline sales to assume" to "Sales to assume" in editor tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)