### PR TITLE
Allow workflow to succeed if jar reject.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -478,3 +478,4 @@ jobs:
           USERNAME: ${{ github.actor }}
           PUBLISH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: cd engine; ./gradlew publish
+        continue-on-error: true  # Allow jar reject on documentation-only deploys


### PR DESCRIPTION
To accomodate documentation only deploys, allow the jar publish to be rejected but still mark the workflow as successful.