### PR TITLE
Ensure big decimal precision.

### DIFF
--- a/engine/src/main/java/org/kigalisim/engine/state/RechargeInformation.java
+++ b/engine/src/main/java/org/kigalisim/engine/state/RechargeInformation.java
@@ -10,6 +10,7 @@
 package org.kigalisim.engine.state;
 
 import java.math.BigDecimal;
+import java.math.MathContext;
 import org.kigalisim.engine.number.EngineNumber;
 
 /**
@@ -110,7 +111,7 @@ public class RechargeInformation {
       BigDecimal totalWeight = currentWeight.add(addedWeight);
       return currentWeight.multiply(intensity.getValue())
           .add(addedWeight.multiply(newIntensity.getValue()))
-          .divide(totalWeight, 10, java.math.RoundingMode.HALF_UP);
+          .divide(totalWeight, MathContext.DECIMAL128);
     }
   }
 }

--- a/engine/src/main/java/org/kigalisim/engine/state/SimulationState.java
+++ b/engine/src/main/java/org/kigalisim/engine/state/SimulationState.java
@@ -7,7 +7,7 @@
 package org.kigalisim.engine.state;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
+import java.math.MathContext;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -638,7 +638,7 @@ public class SimulationState {
       if (isZero) {
         newAge = BigDecimal.ZERO; // Avoid division by zero
       } else {
-        newAge = priorAgeWeighted.add(addedAgeWeighted).divide(totalWeight, 10, RoundingMode.HALF_UP);
+        newAge = priorAgeWeighted.add(addedAgeWeighted).divide(totalWeight, MathContext.DECIMAL128);
       }
 
       setSimpleStream(useKey, "age", new EngineNumber(newAge, "years"));
@@ -1437,8 +1437,8 @@ public class SimulationState {
       newRecycleRechargeAmount = totalRecycleKg.divide(new BigDecimal("2"));
       newRecycleEolAmount = totalRecycleKg.divide(new BigDecimal("2"));
     } else {
-      BigDecimal rechargePercent = recycleRechargeKg.divide(totalExistingRecycle, 10, BigDecimal.ROUND_HALF_UP);
-      BigDecimal eolPercent = recycleEolKg.divide(totalExistingRecycle, 10, BigDecimal.ROUND_HALF_UP);
+      BigDecimal rechargePercent = recycleRechargeKg.divide(totalExistingRecycle, MathContext.DECIMAL128);
+      BigDecimal eolPercent = recycleEolKg.divide(totalExistingRecycle, MathContext.DECIMAL128);
 
       newRecycleRechargeAmount = totalRecycleKg.multiply(rechargePercent);
       newRecycleEolAmount = totalRecycleKg.multiply(eolPercent);
@@ -1869,7 +1869,7 @@ public class SimulationState {
       param.setAppliedRetirementAmount(new EngineNumber(BigDecimal.ZERO, "units"));
     } else {
       BigDecimal retirePercent = appliedRetire.getValue().divide(
-          retireBase.getValue(), 10, java.math.RoundingMode.HALF_UP);
+          retireBase.getValue(), MathContext.DECIMAL128);
 
       BigDecimal newApplied = newPriorUnits.getValue().multiply(retirePercent);
 
@@ -1901,7 +1901,7 @@ public class SimulationState {
       param.setAppliedRechargeAmount(new EngineNumber(BigDecimal.ZERO, "kg"));
     } else {
       BigDecimal baseRatio = newPriorUnits.getValue().divide(
-          rechargeBase.getValue(), 10, java.math.RoundingMode.HALF_UP);
+          rechargeBase.getValue(), MathContext.DECIMAL128);
 
       BigDecimal newApplied = appliedRecharge.getValue().multiply(baseRatio);
 

--- a/engine/src/main/java/org/kigalisim/engine/support/DivisionHelper.java
+++ b/engine/src/main/java/org/kigalisim/engine/support/DivisionHelper.java
@@ -10,7 +10,7 @@
 package org.kigalisim.engine.support;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
+import java.math.MathContext;
 
 /**
  * Helper class for mathematical division operations.
@@ -35,7 +35,7 @@ public class DivisionHelper {
     if (denominatorIsZero) {
       return BigDecimal.ZERO;
     } else {
-      return numerator.divide(denominator, 10, RoundingMode.HALF_UP);
+      return numerator.divide(denominator, MathContext.DECIMAL128);
     }
   }
 }

--- a/engine/src/main/java/org/kigalisim/lang/machine/SingleThreadPushDownMachine.java
+++ b/engine/src/main/java/org/kigalisim/lang/machine/SingleThreadPushDownMachine.java
@@ -7,7 +7,7 @@
 package org.kigalisim.lang.machine;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
+import java.math.MathContext;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Stack;
@@ -112,7 +112,7 @@ public class SingleThreadPushDownMachine implements PushDownMachine {
     }
     setExpectedUnits(right.getUnits());
     EngineNumber left = pop();
-    BigDecimal resultValue = left.getValue().divide(right.getValue(), 10, RoundingMode.HALF_UP);
+    BigDecimal resultValue = left.getValue().divide(right.getValue(), MathContext.DECIMAL128);
     EngineNumber result = new EngineNumber(resultValue, getExpectedUnits());
     push(result);
     clearExpectedUnits();

--- a/engine/src/test/java/org/kigalisim/engine/state/RechargeInformationTest.java
+++ b/engine/src/test/java/org/kigalisim/engine/state/RechargeInformationTest.java
@@ -105,9 +105,9 @@ public class RechargeInformationTest {
         "Population should be 30 (10 + 20)");
 
     // Expected intensity: (10 * 2.0 + 20 * 3.0) / (10 + 20) = 80 / 30 = 2.6666...
-    // With HALF_UP rounding at 10 decimal places
     BigDecimal expectedIntensity = new BigDecimal("2.6666666667");
-    assertEquals(expectedIntensity, result.getIntensity().getValue(),
+    BigDecimal difference = result.getIntensity().getValue().subtract(expectedIntensity).abs();
+    assertEquals(true, difference.compareTo(new BigDecimal("0.000001")) < 0,
         "Intensity should be weighted average: (10*2.0 + 20*3.0)/(10+20)");
   }
 
@@ -131,9 +131,10 @@ public class RechargeInformationTest {
         "Population should be 10");
 
     // Expected: (5 * 1.0 + 5 * 3.0) / 10 = 20 / 10 = 2.0
-    // With HALF_UP rounding at 10 decimal places: 2.0000000000
-    assertEquals(new BigDecimal("2.0000000000"), result.getIntensity().getValue(),
-        "Intensity should be 2.0 with 10 decimal places (average of 1.0 and 3.0)");
+    BigDecimal expectedIntensity = new BigDecimal("2.0");
+    BigDecimal difference = result.getIntensity().getValue().subtract(expectedIntensity).abs();
+    assertEquals(true, difference.compareTo(new BigDecimal("0.000001")) < 0,
+        "Intensity should be 2.0 (average of 1.0 and 3.0)");
   }
 
   /**
@@ -161,7 +162,8 @@ public class RechargeInformationTest {
     // Expected: (|20| * 2.0 + |-10| * 4.0) / (|20| + |-10|) = (40 + 40) / 30 = 80 / 30
     // = 2.6666...
     BigDecimal expectedIntensity = new BigDecimal("2.6666666667");
-    assertEquals(expectedIntensity, result.getIntensity().getValue(),
+    BigDecimal difference = result.getIntensity().getValue().subtract(expectedIntensity).abs();
+    assertEquals(true, difference.compareTo(new BigDecimal("0.000001")) < 0,
         "Intensity should use absolute weights: (20*2.0 + 10*4.0)/(20+10)");
   }
 
@@ -185,9 +187,10 @@ public class RechargeInformationTest {
         "Population should remain 10");
 
     // Expected: (10 * 2.5 + 0 * 3.5) / 10 = 25 / 10 = 2.5
-    // With HALF_UP rounding at 10 decimal places: 2.5000000000
-    assertEquals(new BigDecimal("2.5000000000"), result.getIntensity().getValue(),
-        "Intensity should remain 2.5 with 10 decimal places (zero addition doesn't change average)");
+    BigDecimal expectedIntensity = new BigDecimal("2.5");
+    BigDecimal difference = result.getIntensity().getValue().subtract(expectedIntensity).abs();
+    assertEquals(true, difference.compareTo(new BigDecimal("0.000001")) < 0,
+        "Intensity should remain 2.5 (zero addition doesn't change average)");
   }
 
   /**
@@ -208,9 +211,10 @@ public class RechargeInformationTest {
     // After first addition: (10*1 + 10*2)/(10+10) = 30/20 = 1.5
     assertEquals(new BigDecimal("20"), result.getPopulation().getValue(),
         "After first add: population should be 20");
-    // With HALF_UP rounding at 10 decimal places: 1.5000000000
-    assertEquals(new BigDecimal("1.5000000000"), result.getIntensity().getValue(),
-        "After first add: intensity should be 1.5 with 10 decimal places");
+    BigDecimal expectedIntensity1 = new BigDecimal("1.5");
+    BigDecimal difference1 = result.getIntensity().getValue().subtract(expectedIntensity1).abs();
+    assertEquals(true, difference1.compareTo(new BigDecimal("0.000001")) < 0,
+        "After first add: intensity should be 1.5");
 
     // Second addition: add 20% at 3.0
     EngineNumber pop3 = new EngineNumber(BigDecimal.valueOf(20), "%");
@@ -220,9 +224,10 @@ public class RechargeInformationTest {
     // After second addition: (20*1.5 + 20*3.0)/(20+20) = (30+60)/40 = 90/40 = 2.25
     assertEquals(new BigDecimal("40"), result.getPopulation().getValue(),
         "After second add: population should be 40");
-    // With HALF_UP rounding at 10 decimal places: 2.2500000000
-    assertEquals(new BigDecimal("2.2500000000"), result.getIntensity().getValue(),
-        "After second add: intensity should be 2.25 with 10 decimal places");
+    BigDecimal expectedIntensity2 = new BigDecimal("2.25");
+    BigDecimal difference2 = result.getIntensity().getValue().subtract(expectedIntensity2).abs();
+    assertEquals(true, difference2.compareTo(new BigDecimal("0.000001")) < 0,
+        "After second add: intensity should be 2.25");
   }
 
   /**
@@ -272,7 +277,8 @@ public class RechargeInformationTest {
     // Expected: (0.001 * 1.5 + 0.002 * 2.5) / 0.003 = (0.0015 + 0.005) / 0.003
     // = 0.0065 / 0.003 = 2.1666...
     BigDecimal expectedIntensity = new BigDecimal("2.1666666667");
-    assertEquals(expectedIntensity, result.getIntensity().getValue(),
+    BigDecimal difference = result.getIntensity().getValue().subtract(expectedIntensity).abs();
+    assertEquals(true, difference.compareTo(new BigDecimal("0.000001")) < 0,
         "Intensity should maintain precision with small values");
   }
 
@@ -298,7 +304,8 @@ public class RechargeInformationTest {
     // Expected: (|-5| * 2.0 + |10| * 3.0) / (|-5| + |10|) = (10 + 30) / 15 = 40 / 15
     // = 2.6666...
     BigDecimal expectedIntensity = new BigDecimal("2.6666666667");
-    assertEquals(expectedIntensity, result.getIntensity().getValue(),
+    BigDecimal difference = result.getIntensity().getValue().subtract(expectedIntensity).abs();
+    assertEquals(true, difference.compareTo(new BigDecimal("0.000001")) < 0,
         "Intensity should use absolute weights correctly");
   }
 

--- a/engine/src/test/java/org/kigalisim/engine/support/DivisionHelperTest.java
+++ b/engine/src/test/java/org/kigalisim/engine/support/DivisionHelperTest.java
@@ -9,7 +9,7 @@ package org.kigalisim.engine.support;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
+import java.math.MathContext;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -30,9 +30,9 @@ public class DivisionHelperTest {
     BigDecimal numerator = new BigDecimal("10.0");
     BigDecimal denominator = new BigDecimal("3.0");
     BigDecimal result = DivisionHelper.divideWithZero(numerator, denominator);
-    BigDecimal expected = new BigDecimal("10.0")
-        .divide(new BigDecimal("3.0"), 10, RoundingMode.HALF_UP);
-    assertEquals(expected, result);
+    BigDecimal expected = new BigDecimal("3.3333333333");
+    BigDecimal difference = result.subtract(expected).abs();
+    assertEquals(true, difference.compareTo(new BigDecimal("0.000001")) < 0);
   }
 
   @Test


### PR DESCRIPTION
Previously we were trying to be clever about places where we could do a faster division but it can lead to some imprecision and, in particular, brittle tests. Changing to use 128 bit where we had half up and modifying tests to use an abs diff.

Note that Claude did help reduce some repetition in code migration but followed pattern that I set (smarter find / replace).