### PR TITLE
Add operation fragment for power.

### DIFF
--- a/engine/.idea/misc.xml
+++ b/engine/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_19" project-jdk-name="21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/engine/src/main/java/org/kigalisim/lang/QubecTalkEngineVisitor.java
+++ b/engine/src/main/java/org/kigalisim/lang/QubecTalkEngineVisitor.java
@@ -45,6 +45,7 @@ import org.kigalisim.lang.operation.InitialChargeOperation;
 import org.kigalisim.lang.operation.LogicalOperation;
 import org.kigalisim.lang.operation.MultiplicationOperation;
 import org.kigalisim.lang.operation.Operation;
+import org.kigalisim.lang.operation.PowerOperation;
 import org.kigalisim.lang.operation.PreCalculatedOperation;
 import org.kigalisim.lang.operation.RechargeOperation;
 import org.kigalisim.lang.operation.RecoverOperation;
@@ -178,7 +179,9 @@ public class QubecTalkEngineVisitor extends QubecTalkBaseVisitor<Fragment> {
    */
   @Override
   public Fragment visitPowExpression(QubecTalkParser.PowExpressionContext ctx) {
-    return visitChildren(ctx);
+    Operation left = visit(ctx.expression(0)).getOperation();
+    Operation right = visit(ctx.expression(1)).getOperation();
+    return new OperationFragment(new PowerOperation(left, right));
   }
 
   /**

--- a/engine/src/main/java/org/kigalisim/lang/machine/PushDownMachine.java
+++ b/engine/src/main/java/org/kigalisim/lang/machine/PushDownMachine.java
@@ -196,4 +196,12 @@ public interface PushDownMachine {
    * operand (next on stack) is the low bound. Pushes the sampled value to the top of the stack.</p>
    */
   void drawUniform();
+
+  /**
+   * Raise a number to a power.
+   *
+   * <p>The right operand (top of stack) is the power and the left operand is the base (next on
+   * stack). Goes through double.</p>
+   */
+  void power();
 }

--- a/engine/src/main/java/org/kigalisim/lang/machine/SingleThreadPushDownMachine.java
+++ b/engine/src/main/java/org/kigalisim/lang/machine/SingleThreadPushDownMachine.java
@@ -105,6 +105,23 @@ public class SingleThreadPushDownMachine implements PushDownMachine {
    * {@inheritDoc}
    */
   @Override
+  public void power() {
+    EngineNumber right = pop();
+    EngineNumber left = pop();
+    setExpectedUnits(left.getUnits());
+    BigDecimal resultValue = BigDecimal.valueOf(Math.pow(
+        left.getValue().doubleValue(),
+        right.getValue().doubleValue()
+    ));
+    EngineNumber result = new EngineNumber(resultValue, getExpectedUnits());
+    push(result);
+    clearExpectedUnits();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
   public void divide() {
     EngineNumber right = pop();
     if (right.getValue().compareTo(BigDecimal.ZERO) == 0) {

--- a/engine/src/main/java/org/kigalisim/lang/operation/PowerOperation.java
+++ b/engine/src/main/java/org/kigalisim/lang/operation/PowerOperation.java
@@ -1,0 +1,37 @@
+/**
+ * Calculation which performs an addition inside a PushDownMachine.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.kigalisim.lang.operation;
+
+import org.kigalisim.lang.machine.PushDownMachine;
+
+/**
+ * Calculation that raises one number to the power of another.
+ */
+public class PowerOperation implements Operation {
+
+  private final Operation left;
+  private final Operation right;
+
+  /**
+   * Create a new PowerOperation.
+   *
+   * @param left The left operand of the power operation (base).
+   * @param right The right operand of the power (power).
+   */
+  public PowerOperation(Operation left, Operation right) {
+    this.left = left;
+    this.right = right;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void execute(PushDownMachine machine) {
+    left.execute(machine);
+    right.execute(machine);
+    machine.power();
+  }
+}

--- a/examples/sigmoid_retire.qta
+++ b/examples/sigmoid_retire.qta
@@ -1,0 +1,24 @@
+start default
+
+  define application "test"
+
+    uses substance "test"
+      enable import
+      assume only recharge sales
+      initial charge with 15 kg / unit for import
+      set priorEquipment to 100 units during year 2022
+      retire 1 / (1+2.71828^(-0.3*((get age as years)-20))) % / year
+      recharge 12 % with 15 kg / unit
+    end substance
+
+  end application
+
+end default
+
+
+start simulations
+
+  simulate "BAU"
+  from years 2022 to 2050
+
+end simulations


### PR DESCRIPTION
The operation fragment for power was accidentially left off on the roadmap. This resolves that oversight. Our apologies! This impacted a small number of users leveraging power in custom formulas like from UI but did not impact engine internal calculations or most operations.