### PR TITLE
Improve flexibility for stream query.

### DIFF
--- a/engine/src/main/java/org/kigalisim/lang/QubecTalkEngineVisitor.java
+++ b/engine/src/main/java/org/kigalisim/lang/QubecTalkEngineVisitor.java
@@ -42,6 +42,7 @@ import org.kigalisim.lang.operation.FloorOperation;
 import org.kigalisim.lang.operation.GetStreamOperation;
 import org.kigalisim.lang.operation.GetVariableOperation;
 import org.kigalisim.lang.operation.InitialChargeOperation;
+import org.kigalisim.lang.operation.JointOperation;
 import org.kigalisim.lang.operation.LogicalOperation;
 import org.kigalisim.lang.operation.MultiplicationOperation;
 import org.kigalisim.lang.operation.Operation;
@@ -50,6 +51,7 @@ import org.kigalisim.lang.operation.PreCalculatedOperation;
 import org.kigalisim.lang.operation.RechargeOperation;
 import org.kigalisim.lang.operation.RecoverOperation;
 import org.kigalisim.lang.operation.RecoverOperation.RecoveryStage;
+import org.kigalisim.lang.operation.RemoveUnitsOperation;
 import org.kigalisim.lang.operation.ReplaceOperation;
 import org.kigalisim.lang.operation.RetireOperation;
 import org.kigalisim.lang.operation.RetireWithReplacementOperation;
@@ -207,7 +209,10 @@ public class QubecTalkEngineVisitor extends QubecTalkBaseVisitor<Fragment> {
     UnitFragment unitFragment = (UnitFragment) visit(ctx.conversion);
     String unitConversion = unitFragment.getUnit();
 
-    Operation operation = new GetStreamOperation(streamName, unitConversion);
+    Operation operation = new JointOperation(
+        new GetStreamOperation(streamName, unitConversion),
+        new RemoveUnitsOperation()
+    );
 
     return new OperationFragment(operation);
   }
@@ -233,7 +238,10 @@ public class QubecTalkEngineVisitor extends QubecTalkBaseVisitor<Fragment> {
     UnitFragment unitFragment = (UnitFragment) visit(ctx.conversion);
     String unitConversion = unitFragment.getUnit();
 
-    Operation operation = new GetStreamOperation(streamName, targetSubstance, unitConversion);
+    Operation operation = new JointOperation(
+        new GetStreamOperation(streamName, targetSubstance, unitConversion),
+        new RemoveUnitsOperation()
+    );
 
     return new OperationFragment(operation);
   }
@@ -303,7 +311,10 @@ public class QubecTalkEngineVisitor extends QubecTalkBaseVisitor<Fragment> {
 
     String targetSubstance = visit(ctx.rescope).getString();
 
-    Operation operation = new GetStreamOperation(streamName, targetSubstance, null);
+    Operation operation = new JointOperation(
+        new GetStreamOperation(streamName, targetSubstance, null),
+        new RemoveUnitsOperation()
+    );
 
     return new OperationFragment(operation);
   }
@@ -340,7 +351,10 @@ public class QubecTalkEngineVisitor extends QubecTalkBaseVisitor<Fragment> {
   public Fragment visitGetStream(QubecTalkParser.GetStreamContext ctx) {
     String streamName = visit(ctx.target).getString();
 
-    Operation operation = new GetStreamOperation(streamName);
+    Operation operation = new JointOperation(
+        new GetStreamOperation(streamName),
+        new RemoveUnitsOperation()
+    );
 
     return new OperationFragment(operation);
   }

--- a/engine/src/main/java/org/kigalisim/lang/machine/PushDownMachine.java
+++ b/engine/src/main/java/org/kigalisim/lang/machine/PushDownMachine.java
@@ -82,6 +82,16 @@ public interface PushDownMachine {
   void changeUnits(String units);
 
   /**
+   * Change the units of the number at the top of the stack, optionally forcing the change.
+   *
+   * @param units The new units for the number at the top of the stack.
+   * @param force If true, force the unit change even if the current units do not match.
+   * @throws RuntimeException If the stack is empty, or if force is false and the top value already
+   *     has units which do not match the desired units.
+   */
+  void changeUnits(String units, boolean force);
+
+  /**
    * Get the engine in which this machine is running.
    *
    * @return The engine in which this machine is running.

--- a/engine/src/main/java/org/kigalisim/lang/machine/SingleThreadPushDownMachine.java
+++ b/engine/src/main/java/org/kigalisim/lang/machine/SingleThreadPushDownMachine.java
@@ -140,9 +140,17 @@ public class SingleThreadPushDownMachine implements PushDownMachine {
    */
   @Override
   public void changeUnits(String units) {
+    changeUnits(units, false);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void changeUnits(String units, boolean force) {
     EngineNumber top = pop();
     boolean allowed = top.getUnits().isEmpty() || top.getUnits().equals(units);
-    if (!allowed) {
+    if (!allowed && !force) {
       String message = String.format(
           "Unexpected units for top value. Anticipated empty or %s but got %s.",
           units,

--- a/engine/src/main/java/org/kigalisim/lang/operation/JointOperation.java
+++ b/engine/src/main/java/org/kigalisim/lang/operation/JointOperation.java
@@ -1,0 +1,37 @@
+/**
+ * Operation which combines two other operations.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.kigalisim.lang.operation;
+
+import org.kigalisim.lang.machine.PushDownMachine;
+
+
+/**
+ * Conjunction operation which performs one operation followed by another.
+ */
+public class JointOperation implements Operation {
+
+  private final Operation inner;
+  private final Operation outer;
+
+  /**
+   * Create a new joint operation which persoms one followed by another.
+   *
+   * @param inner The first operation to perform.
+   * @param outer The second opeation to perform.
+   */
+  public JointOperation(Operation inner, Operation outer) {
+    this.inner = inner;
+    this.outer = outer;
+  }
+
+  @Override
+  public void execute(PushDownMachine machine) {
+    inner.execute(machine);
+    outer.execute(machine);
+  }
+
+}

--- a/engine/src/main/java/org/kigalisim/lang/operation/RemoveUnitsOperation.java
+++ b/engine/src/main/java/org/kigalisim/lang/operation/RemoveUnitsOperation.java
@@ -1,0 +1,25 @@
+/**
+ * Operation to force a change in units while maintaining value.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.kigalisim.lang.operation;
+
+import org.kigalisim.lang.machine.PushDownMachine;
+
+
+/**
+ * Operation which maintains the same value but forces a change to units.
+ *
+ * <p>Operation which takes the top value of a push-down machine and forces it to have a
+ * specific units value while maintaining the same numeric value.</p>
+ */
+public class RemoveUnitsOperation implements Operation {
+
+  @Override
+  public void execute(PushDownMachine machine) {
+    machine.changeUnits("", true);
+  }
+
+}

--- a/engine/src/test/java/org/kigalisim/lang/machine/SingleThreadPushDownMachineTest.java
+++ b/engine/src/test/java/org/kigalisim/lang/machine/SingleThreadPushDownMachineTest.java
@@ -165,6 +165,18 @@ public class SingleThreadPushDownMachineTest {
   }
 
   /**
+   * Test that changeUnits can force a change.
+   */
+  @Test
+  public void testChangeUnitsUnitsForce() {
+    machine.push(new EngineNumber(BigDecimal.valueOf(42), "kg"));
+    machine.changeUnits("liters", true);
+    EngineNumber result = machine.getResult();
+    assertEquals(BigDecimal.valueOf(42), result.getValue(), "Value should be preserved after changing units");
+    assertEquals("liters", result.getUnits(), "Units should change");
+  }
+
+  /**
    * Test the multiply operation.
    */
   @Test

--- a/examples/retire_with_advance_parameter_flip.qta
+++ b/examples/retire_with_advance_parameter_flip.qta
@@ -1,0 +1,23 @@
+start default
+
+  define application "test"
+
+    uses substance "test"
+      enable domestic
+      initial charge with 1 kg / unit for domestic
+      set priorEquipment to 100 mt during year 1
+      set sales to 0 units
+      retire 10 * (get age as years) %
+      equals 5 tCO2e / mt
+    end substance
+
+  end application
+
+end default
+
+
+start simulations
+
+  simulate "business as usual" from years 1 to 10
+
+end simulations


### PR DESCRIPTION
Improve the flexiblity of ordering values in formulas so that get stream can appear before or after. This works by adding an operation to remove units (RemoveUnitsOperation) from something being used in a formula (along with JointOperation to facilitate). This then allows the value to use the units given / mandated by the user.

Claude fixed style issues but did not fundamentally author solution so not listing as co-author.