### PR TITLE
Add explanation of equipment count in permit case

### DIFF
--- a/docs/guide/tutorial_05.html
+++ b/docs/guide/tutorial_05.html
@@ -180,7 +180,7 @@
         </p>
 
         <p>
-          As a teaser for later, you might notice is that the equipment count is higher in the permit case than BAU. This is because we are assuming displaced volumes of substance. As the initial charge for R-600a is lower than HFC-134a, that results in more equipment. Depending on what you assume economically, this might be incorrect. However, we can model with displaced units of equipment instead, a topic we will see very soon in <a href="/guide/tutorial_08.html">Tutorial 8</a>.
+          As a teaser for later, you might notice that the equipment count is higher in the permit case than BAU. This is because we are assuming displaced volumes of substance. As the initial charge for R-600a is lower than HFC-134a, that results in more equipment. Depending on what you assume economically, this might be incorrect. However, we can model with displaced units of equipment instead, a topic we will see very soon in <a href="/guide/tutorial_08.html">Tutorial 8</a>.
         </p>
       </section>
 


### PR DESCRIPTION
Added a paragraph explaining equipment count differences in permit case versus BAU due to assumptions about displaced volumes of substance.