### PR TITLE
Add alphabetical sorting to UI lists and update changelog

### DIFF
--- a/beta_changelog.md
+++ b/beta_changelog.md
@@ -14,6 +14,14 @@ Finally, we want to again express our gratitude for your feedback and time.
 
 The following changes have been adopted and released.
 
+### Alphabetical sorting in UI lists
+
+**Status**: Released January 20, 2026
+
+**Classification**: Enhancement
+
+Added alphabetical sorting to all UI-based editor lists and checkboxes. Applications, substances (consumptions), policies, and simulations are now displayed in alphabetical order in their respective list views. Policy checkboxes in the simulation dialog are also sorted alphabetically, and when policies are selected and converted to a simulation stanza via `policy-check-label`, they now appear in alphabetical order in the generated code.
+
 ### Displacement options
 
 **Status**: Released December 30, 2025

--- a/editor/js/ui_editor.js
+++ b/editor/js/ui_editor.js
@@ -259,7 +259,7 @@ class ApplicationsListPresenter {
     const codeObj = self._getCodeObj();
     const applications = codeObj.getApplications();
     const appNames = applications.map((x) => x.getName());
-    return appNames;
+    return appNames.sort();
   }
 }
 
@@ -958,7 +958,7 @@ class ConsumptionListPresenter {
       });
     });
     const consumptions = consumptionsNested.flat();
-    return consumptions;
+    return consumptions.sort();
   }
 
   /**
@@ -1610,7 +1610,7 @@ class PolicyListPresenter {
     const self = this;
     const codeObj = self._getCodeObj();
     const policies = codeObj.getPolicies();
-    return policies.map((x) => x.getName());
+    return policies.map((x) => x.getName()).sort();
   }
 
   /**
@@ -1891,7 +1891,8 @@ class SimulationListPresenter {
     const policyNames = self
       ._getCodeObj()
       .getPolicies()
-      .map((x) => x.getName());
+      .map((x) => x.getName())
+      .sort();
     const newLabels = d3
       .select(self._dialog.querySelector(".policy-sim-list"))
       .html("")
@@ -1924,7 +1925,7 @@ class SimulationListPresenter {
     const self = this;
     const codeObj = self._getCodeObj();
     const scenarios = codeObj.getScenarios();
-    return scenarios.map((x) => x.getName());
+    return scenarios.map((x) => x.getName()).sort();
   }
 
   /**
@@ -1985,7 +1986,7 @@ class SimulationListPresenter {
 
     const policyChecks = Array.of(...self._dialog.querySelectorAll(".policy-check"));
     const policiesChecked = policyChecks.filter((x) => x.checked);
-    const policyNamesSelected = policiesChecked.map((x) => x.value);
+    const policyNamesSelected = policiesChecked.map((x) => x.value).sort();
 
     return new SimulationScenario(scenarioName, policyNamesSelected, start, end, true);
   }


### PR DESCRIPTION
Sort applications, substances, policies, and simulations alphabetically in UI-based editor lists and checkboxes. Policy selections in simulation stanzas are now also sorted alphabetically in generated code.