### PR TITLE
Clear policy checkboxes on new scenario.

### DIFF
--- a/editor/test/test_ui_editor_sim.js
+++ b/editor/test/test_ui_editor_sim.js
@@ -343,6 +343,8 @@ function buildUiEditorSimTests() {
         _showForSimpleOrdering: SimulationListPresenter.prototype._showForSimpleOrdering,
         _updateMoveControlVisibility:
           SimulationListPresenter.prototype._updateMoveControlVisibility,
+        _readPoliciesEnabled: SimulationListPresenter.prototype._readPoliciesEnabled,
+        _wrapPolicyList: SimulationListPresenter.prototype._wrapPolicyList,
         _orderControlsTemplate: document.getElementById("sim-order-controls-template").innerHTML,
       };
 
@@ -387,6 +389,8 @@ function buildUiEditorSimTests() {
           _showForSimpleOrdering: SimulationListPresenter.prototype._showForSimpleOrdering,
           _updateMoveControlVisibility:
             SimulationListPresenter.prototype._updateMoveControlVisibility,
+          _readPoliciesEnabled: SimulationListPresenter.prototype._readPoliciesEnabled,
+          _wrapPolicyList: SimulationListPresenter.prototype._wrapPolicyList,
           _orderControlsTemplate: document.getElementById("sim-order-controls-template").innerHTML,
         };
 


### PR DESCRIPTION
Clear the policy checkboxes in the scenario dialog when the user elects to make a new policy. Currently, the prior selection caries over.