### PR TITLE
Remove embedded HTML video elements from tutorial markdown files

### DIFF
--- a/docs/guide/md/tutorial_02.md
+++ b/docs/guide/md/tutorial_02.md
@@ -18,8 +18,6 @@ Let's start by creating a new simulation for ABC:
 
 You won't see results yet because we haven't added any substances or equipment data.
 
-<video src="/webm/tutorial_02_01.webm" autoplay loop muted playsinline style="width: 500px; border: 2px solid #505050; border-radius: 3px;">Your browser does not support the video tag. Please upgrade to a modern browser.</video>
-
 ## Adding HFC-134a Substance
 
 Next, let's add our refrigerant substance:
@@ -35,8 +33,6 @@ Don't click save yet! We need to configure equipment properties first.
 
 > **More about greenhouse gas emissions**: In Kigali Sim the GHG equivalency or intensity is the same as the global warming potential (GWP) of the substance. Our value means 1430 kg of CO2 equivalent per kilogram of substance. You can also use other units like 1.43 tCO2e/kg.
 
-<video src="/webm/tutorial_02_02.webm" autoplay loop muted playsinline style="width: 500px; border: 2px solid #505050; border-radius: 3px;">Your browser does not support the video tag. Please upgrade to a modern browser.</video>
-
 ## Equipment Properties
 
 Now let's define the equipment characteristics that drive HFC consumption:
@@ -51,8 +47,6 @@ Now let's define the equipment characteristics that drive HFC consumption:
 
 These basic parameters are enough to start modeling, but we also will want to account for servicing existing equipment.
 
-<video src="/webm/tutorial_02_03.webm" autoplay loop muted playsinline style="width: 500px; border: 2px solid #505050; border-radius: 3px;">Your browser does not support the video tag. Please upgrade to a modern browser.</video>
-
 ## Servicing Configuration
 
 Refrigerants are needed both for new equipment (initial charge) and maintenance of existing equipment:
@@ -65,8 +59,6 @@ Refrigerants are needed both for new equipment (initial charge) and maintenance 
 
 We're almost ready to run our first simulation! We just need initial conditions.
 
-<video src="/webm/tutorial_02_04.webm" autoplay loop muted playsinline style="width: 500px; border: 2px solid #505050; border-radius: 3px;">Your browser does not support the video tag. Please upgrade to a modern browser.</video>
-
 ## Initial Conditions
 
 Head to the **Set tab** to specify ABC Country's starting conditions:
@@ -76,8 +68,6 @@ Head to the **Set tab** to specify ABC Country's starting conditions:
 - Set **domestic** manufacture to **25 mt / yr** in year 2025
 
 This 25 mt/year gives us a good demonstrative curve showing how consumption patterns evolve. However, until we specify changes in later tutorials, this production rate will remain steady based on tonnage. It will be used both for initial charge and recharge.
-
-<video src="/webm/tutorial_02_05.webm" autoplay loop muted playsinline style="width: 500px; border: 2px solid #505050; border-radius: 3px;">Your browser does not support the video tag. Please upgrade to a modern browser.</video>
 
 > **More about default sales assumptions**: Below the setpoints, you may see a "Default sales assumption in a new year" dropdown. For this tutorial (and most simulations), leave this set to "Continue from last year (recommended)" which is the default. This setting controls how sales carry over from one year to the next. The default option maintains existing sales patterns, allowing the model to automatically balance substance allocation between initial charge and recharge based on equipment population dynamics. In other words, it assumes that prior sales levels persist until other indication is provided.
 
@@ -90,8 +80,6 @@ Now let's see our model in action. After clicking save for our consumption recor
 - Set no policies (we'll add those later).
 - Indicate a duration from **2025 to 2035**
 - Click **Finish**
-
-<video src="/webm/tutorial_02_06.webm" autoplay loop muted playsinline style="width: 500px; border: 2px solid #505050; border-radius: 3px;">Your browser does not support the video tag. Please upgrade to a modern browser.</video>
 
 ## Interpreting Results
 
@@ -114,8 +102,6 @@ We will add additional dynamics but this starts building an intuition for how Ki
 > In any case, emissions excludes substance captured prior to emitting. A topic revisited in a later tutorial, this includes substance captured and destroyed or recycled.
 
 > **More about bank**: We will return to the concept of the bank in later sections of this tutorial series. However, at a high level, this refers to all of the equipment and substance not yet emitted within the country. The "bank measures" allow us to see what that population of machinery and reservoir of substance looks like. Even if policies and treaty mechanisms often do not directly address these metrics, this may be important to understand when modeling.
-
-<video src="/webm/tutorial_02_07.webm" autoplay loop muted playsinline style="width: 500px; border: 2px solid #505050; border-radius: 3px;">Your browser does not support the video tag. Please upgrade to a modern browser.</video>
 
 ## Conclusion
 

--- a/docs/guide/md/tutorial_03.md
+++ b/docs/guide/md/tutorial_03.md
@@ -24,8 +24,6 @@ Let's practice the functionality we explored in the prior tutorial. Use the same
 
 We will add in socioeconomic projections soon but, for now, consumption volumes will continue unchanged into the future.
 
-<video src="/webm/tutorial_03_01.webm" loop muted playsinline controls style="width: 500px; border: 2px solid #505050; border-radius: 3px;">Your browser does not support the video tag. Please upgrade to a modern browser.</video>
-
 **Note**: Kigali Sim requires decimal point number formatting (comma for thousands separator, period for decimal point, ex: `123,456.7` or `40,000.0`). If you use alternative formatting (ex: `123.456,7`), Kigali Sim will display a message with a suggestion for the equivalent supported format. Both formatting conventions are internationally valid, but Kigali Sim uses the DecimalFormat format for consistency with the technologies it leverages. This means `40,000` is interpreted as forty thousand.
 
 ## Interpreting Multi-Application Results
@@ -34,11 +32,7 @@ As you work, the simulation will update automatically.
 
 Examine the results to understand how multiple applications and substances add together. You can do this by looking at results by selecting the **Application** or **Substances** radio buttons. To get a complete picture with the **Emissions** radio button, try clicking **"configure custom"** under emissions and combining both end-of-life and recharge emissions. This represents the total leakage throughout the equipment lifetime.
 
-<video src="/webm/tutorial_03_02.webm" loop muted playsinline controls style="width: 500px; border: 2px solid #505050; border-radius: 3px;">Your browser does not support the video tag. Please upgrade to a modern browser.</video>
-
 Before concluding, let's also pause to understand if these results make sense. First, the custom emissions which combines both end of life and recharge emissions is higher than either alone. Second, consider that the HFC-134a has higher volume and higher GWP than R-600a. Therefore, focusing on HFC-134a, we notice that these two factors intersect through a larger gap to R-600a in emissions relative to consumption when we have selected the **Substances** radio button.
-
-<video src="/webm/tutorial_03_03.webm" loop muted playsinline controls style="width: 500px; border: 2px solid #505050; border-radius: 3px;">Your browser does not support the video tag. Please upgrade to a modern browser.</video>
 
 ## Conclusion
 

--- a/docs/guide/md/tutorial_03a.md
+++ b/docs/guide/md/tutorial_03a.md
@@ -80,11 +80,7 @@ As you work, the simulation will update automatically.
 
 Examine the results to understand how multiple applications and substances add together. You can do this by looking at results by selecting the **Application** or **Substances** radio buttons. To get a complete picture with the **Emissions** radio button, try clicking **"configure custom"** under emissions and combining both end-of-life and recharge emissions. This represents the total leakage throughout the equipment lifetime.
 
-<video src="/webm/tutorial_03_02.webm" loop muted playsinline controls style="width: 500px; border: 2px solid #505050; border-radius: 3px;">Your browser does not support the video tag. Please upgrade to a modern browser.</video>
-
 Before concluding, let's also pause to understand if these results make sense. First, the custom emissions which combines both end of life and recharge emissions is higher than either alone. Second, consider that the HFC-134a has higher volume and higher GWP than R-600a. Therefore, focusing on HFC-134a, we notice that these two factors intersect through a larger gap to R-600a in emissions relative to consumption when we have selected the **Substances** radio button.
-
-<video src="/webm/tutorial_03_03.webm" loop muted playsinline controls style="width: 500px; border: 2px solid #505050; border-radius: 3px;">Your browser does not support the video tag. Please upgrade to a modern browser.</video>
 
 ## Conclusion
 

--- a/docs/guide/md/tutorial_04.md
+++ b/docs/guide/md/tutorial_04.md
@@ -20,8 +20,6 @@ Let's say that ABC imports some but not all of their HFC-134a. Therefore, for **
 
 Our tutorial later will expand this further but this gives us a good starting point.
 
-<video src="/webm/tutorial_04_01.webm" autoplay loop muted playsinline style="width: 500px; border: 2px solid #505050; border-radius: 3px;">Your browser does not support the video tag. Please upgrade to a modern browser.</video>
-
 ## First Economic Growth
 
 In addition to trade, let's also add in economic growth. For example, these projections might come from industry surveys or from outside modeling efforts. Let's start with HFC-134a:
@@ -36,8 +34,6 @@ In addition to trade, let's also add in economic growth. For example, these proj
 >
 > Note that this may also include "secondary" substance if recycling is active. That said, indicated by the recover command, recycling capacity is assumed to be limited. So, domestic and import will be modified to satisfy a set or change command after taking the unchanged recycling stream into account. However, using sales with cap/floor (like for permitting) places lower or upper limits on all consumption including recycling. For virgin only, replace sales with individual commands on domestic and import. This will exclude secondary production.
 
-<video src="/webm/tutorial_04_02.webm" autoplay loop muted playsinline style="width: 500px; border: 2px solid #505050; border-radius: 3px;">Your browser does not support the video tag. Please upgrade to a modern browser.</video>
-
 ## Expanding the Growth
 
 Let's continue by applying these growth rates using the **Change** tab for the consumption records. Below is a table of everything that should be present after you are done. However, remember that you already did HFC-134a!
@@ -51,8 +47,6 @@ Let's continue by applying these growth rates using the **Change** tab for the c
 
 You can go to **Change** tab and add changes for domestic manufacture stream or all sales, both have the same effect in this case.
 
-<video src="/webm/tutorial_04_03.webm" autoplay loop muted playsinline style="width: 500px; border: 2px solid #505050; border-radius: 3px;">Your browser does not support the video tag. Please upgrade to a modern browser.</video>
-
 ## Results
 
 Note that the drop down menu under the Consumption radio button which can flip between domestic and imports. Just as we did with the custom metric under emissions before, we can click configure custom to combine imports and domestic together.
@@ -60,8 +54,6 @@ Note that the drop down menu under the Consumption radio button which can flip b
 Does the imports part of HFC-134a seem small? It's important to note that, by default, initial charge for new equipment is attributed to the exporting country. We can temporarily change this behavior to get a fuller picture of our global consumption by checking **Attribute initial charge to importer**. However, to stay consistent with Montreal Protocol standards, uncheck it to review treaty-aligned numbers. When authoring simulations, often it helps to consider both perspectives.
 
 Zooming out, we should see the acceleration in HFC-134a and HFC-32. With the **Emissions** radio button, things still remain quite dominated by HFC-134a. In contrast, the two are closer when selecting the **Consumption** radio button as that 10% increase compounds over time for HFC-32.
-
-<video src="/webm/tutorial_04_04.webm" autoplay loop muted playsinline style="width: 500px; border: 2px solid #505050; border-radius: 3px;">Your browser does not support the video tag. Please upgrade to a modern browser.</video>
 
 ## Conclusion
 

--- a/docs/guide/md/tutorial_04a.md
+++ b/docs/guide/md/tutorial_04a.md
@@ -99,10 +99,6 @@ Does the imports part of HFC-134a seem small? It's important to note that, by de
 
 Zooming out, we should see the acceleration in HFC-134a and HFC-32. With the **Emissions** radio button, things still remain quite dominated by HFC-134a. In contrast, the two are closer when selecting the **Consumption** radio button as that 10% increase compounds over time for HFC-32.
 
-<video src="/webm/tutorial_04_04.webm" autoplay loop muted playsinline controls style="width: 500px; border: 2px solid #505050; border-radius: 3px;">
-Your browser does not support the video tag. Please upgrade to a modern browser.
-</video>
-
 ## Conclusion
 
 You now have ABC Country's realistic business-as-usual scenario incorporating economic growth, trade flows, and technology transitions. You even sped this up through AI! Anyway, this foundation shows how consumption evolves without intervention. Later, we will try out different policies on this of this baseline.

--- a/docs/guide/md/tutorial_05.md
+++ b/docs/guide/md/tutorial_05.md
@@ -19,8 +19,6 @@ For **Domestic Refrigeration**, modify your **R-600a** consumption record:
 
 This gives R-600a a similar import/domestic split as HFC-134a, making the displacement mechanism clearer when we implement the policy.
 
-<video src="/webm/tutorial_05_01.webm" loop muted playsinline controls style="width: 500px; border: 2px solid #505050; border-radius: 3px;">Your browser does not support the video tag. Please upgrade to a modern browser.</video>
-
 ## Adding the Sales Permitting Policy
 
 Now let's create ABC's permitting system that targets HFC-134a in domestic refrigeration, where displaced demand will shift to R-600a.
@@ -32,8 +30,6 @@ Now let's create ABC's permitting system that targets HFC-134a in domestic refri
 - Click **Finish** to finish the policy
 
 > **More about percentages in cap and floor**: Note that percentage caps and floors are relative to the prior year's value by default. You can make this explicit by using `% prior year` instead of `%`.
-
-<video src="/webm/tutorial_05_02.webm" loop muted playsinline controls style="width: 500px; border: 2px solid #505050; border-radius: 3px;">Your browser does not support the video tag. Please upgrade to a modern browser.</video>
 
 ## Creating the Permit Simulation
 
@@ -47,8 +43,6 @@ Now let's create a simulation to see how the permitting policy compares to busin
 
 The simulation will now show both your original **BAU** and new **Permit** scenarios side by side.
 
-<video src="/webm/tutorial_05_03.webm" loop muted playsinline controls style="width: 500px; border: 2px solid #505050; border-radius: 3px;">Your browser does not support the video tag. Please upgrade to a modern browser.</video>
-
 ## Results
 
 Let's observe how:
@@ -59,8 +53,6 @@ Let's observe how:
 
 Specifically, under the **Substances** view with Permit selected under the **Simulations** radio button, you can see how displacement works: as HFC-134a is restricted, R-600a scales up proportionally. Since R-600a now has both domestic and import sources, the displaced demand gets distributed across both supply chains.
 
-<video src="/webm/tutorial_05_04.webm" loop muted playsinline controls style="width: 500px; border: 2px solid #505050; border-radius: 3px;">Your browser does not support the video tag. Please upgrade to a modern browser.</video>
-
 All that said, remember that without **Attribute initial charge to importer** checked, the visualizations show only the substance flows for servicing imported equipment, not their initial charge. Before finishing up, let's just quickly check that box once more and:
 
 - Select the **Simulations** radio button
@@ -69,8 +61,6 @@ All that said, remember that without **Attribute initial charge to importer** ch
 - Use the **configure custom** link to combine imports and domestic production.
 
 The lines almost perfectly overlap when **Attribute initial charge to importer** is checked but are a little further off without it, especially in 2035. This is because, as the import / domestic ratios (and their growth rates) are slightly different for R-600a and HFC-134a, the trade attribution causes the numbers to shift around a bit even though the total global-level picture is essentially balanced. That said, in any case, there are very minor differences expected due to servicing differences between equipment.
-
-<video src="/webm/tutorial_05_05.webm" loop muted playsinline controls style="width: 500px; border: 2px solid #505050; border-radius: 3px;">Your browser does not support the video tag. Please upgrade to a modern browser.</video>
 
 As a teaser for later, you might notice that the equipment count is higher in the permit case than BAU. This is because we are assuming displaced volumes of substance. As the initial charge for R-600a is lower than HFC-134a, that results in more equipment. Depending on what you assume economically, this might be incorrect.
 

--- a/docs/guide/md/tutorial_06.md
+++ b/docs/guide/md/tutorial_06.md
@@ -22,13 +22,9 @@ Let's create ABC's recovery program:
 
 Please leave **induced demand at 100%** (the default). We will revisit this in just a minute.
 
-<video src="/webm/tutorial_06_01.webm" autoplay loop muted playsinline style="width: 500px; border: 2px solid #505050; border-radius: 3px;">Your browser does not support the video tag. Please upgrade to a modern browser.</video>
-
 ## Add Simulations
 
 Add both a Recycling simulation with just Domestic Recycling selected. Then, add a combined simulation with both Sales Permit and Domestic Recycling included. Again, use years 2025 to 2035.
-
-<video src="/webm/tutorial_06_02.webm" autoplay loop muted playsinline style="width: 500px; border: 2px solid #505050; border-radius: 3px;">Your browser does not support the video tag. Please upgrade to a modern browser.</video>
 
 Note: The domestic recycling is applied prior to the sales permit (should appear in the checkbox list of policies first). If not, please use the specify policy order link.
 
@@ -42,8 +38,6 @@ Piecing together what is going on with multiple policies can take a little work 
 
 Next, the **Emissions** radio button tells an interesting story where recycling captures some of those emissions. Also, this is where the combination of policies may be effective. Once we add in the cap as well, the two complement each other to achieve a higher impact than either on their own.
 
-<video src="/webm/tutorial_06_03.webm" autoplay loop muted playsinline style="width: 500px; border: 2px solid #505050; border-radius: 3px;">Your browser does not support the video tag. Please upgrade to a modern browser.</video>
-
 > **More on induced demand**: Note that we said 100% induced demand. This means that virgin consumption does not on its own decrease because recycling is present. This is common in recycling programs where recycling does not 1:1 offset virgin production. Determining the correct rate of displacement (100% - induced demand) can require a bit of work.
 >
 > For comparison, try setting the induced demand to **0%** instead. With 0% induced demand, every kg of recycled substance means one less kg of virgin substance produced, a direct 1:1 offset. First, check the **Bank** view with million units of equipment selected. Notice that BAU and recycling scenarios now have the same amount of equipment, since recycling no longer drives additional demand. Next, switch to **Consumption** and observe that virgin domestic production is now lower in the recycling scenario. Finally, return to **Emissions** to see that they remain lower with recycling in either case, though the mechanism differs between 0% and 100% induced demand. For the purposes of the later tutorials, let's leave induced demand at 100%, but remember that you can try out different values along the way.
@@ -51,8 +45,6 @@ Next, the **Emissions** radio button tells an interesting story where recycling 
 > All that in mind, induced demand is likely neither 0% nor 100% in practice. However, this ambiguity largely goes away when we add the cap policy. When both are employed together, we see a stronger response in terms of emissions. In this case though, it is important to have recycling followed by permit. This is because we want recycling effects calculated first. After all, if there's enough servicing activity, demand is higher than it would be without recycling! Then, the cap policy can reduce whatever virgin sales were after recycling to the mandated levels, offsetting any induced demand over the cap into R-600a instead of leaving it in HFC-134a.
 
 > **More about terminology / bank**: **Bank** refers to all of the equipment and substance (not yet emitted to the atmosphere) in a country. Some call this reservoir. This can be expressed in terms of number of units of equipment, substance volumes, and tCO2e. Kigali Sim uses Bank to refer to the full population of equipment and substance in the country at any given time. This is also where metrics derived from operating characteristics (like energy consumption) are reported.
-
-<video src="/webm/tutorial_06_04.webm" autoplay loop muted playsinline style="width: 500px; border: 2px solid #505050; border-radius: 3px;">Your browser does not support the video tag. Please upgrade to a modern browser.</video>
 
 ## Conclusion
 

--- a/docs/guide/md/tutorial_07.md
+++ b/docs/guide/md/tutorial_07.md
@@ -23,8 +23,6 @@ You'll see that all your work from Tutorials 2-6 has been translated into QubecT
 
 Within each stanza, there are **commands** like `initial charge with 0.07 kg / unit for domestic`.
 
-<video src="/webm/tutorial_07_01.webm" loop muted playsinline controls style="width: 500px; border: 2px solid #505050; border-radius: 3px;">Your browser does not support the video tag. Please upgrade to a modern browser.</video>
-
 ## Editing Code Directly
 
 Let's make a simple change to get comfortable with code editing:
@@ -34,8 +32,6 @@ Let's make a simple change to get comfortable with code editing:
 - Return to the **Design** tab and verify the change appears in the UI by clicking **edit** for HFC-134a
 
 This demonstrates the two-way connection between UI and code - changes in either location update the model.
-
-<video src="/webm/tutorial_07_02.webm" loop muted playsinline controls style="width: 500px; border: 2px solid #505050; border-radius: 3px;">Your browser does not support the video tag. Please upgrade to a modern browser.</video>
 
 ## Implementing R-600a Recycling
 
@@ -86,8 +82,6 @@ In 2035, combined import and domestic for the combined policy case is higher wit
 ```
 
 Now, the combined version sees closer consumption to recycling alone because the demand "displaced" from HFC-134a to R-600a now has a pathway to reuse.
-
-<video src="/webm/tutorial_07_03.webm" loop muted playsinline controls style="width: 500px; border: 2px solid #505050; border-radius: 3px;">Your browser does not support the video tag. Please upgrade to a modern browser.</video>
 
 ## Conclusion
 

--- a/docs/guide/md/tutorial_08.md
+++ b/docs/guide/md/tutorial_08.md
@@ -74,8 +74,6 @@ First, you may notice that switching to units slightly increased overall consump
 
 Second, let's look closer at HFC-134a under the Permit scenario with the **Substances** and **Consumption** radio buttons selected. The combined import and domestic consumption doesn't go to 0 mt. That's because we specified a cap of 0 new units sold but we still have servicing. Try setting the consumption cap back to 0 mt and it will drop all the way.
 
-<video src="/webm/tutorial_08_01.webm" loop muted playsinline controls style="width: 500px; border: 2px solid #505050; border-radius: 3px;">Your browser does not support the video tag. Please upgrade to a modern browser.</video>
-
 Before we wrap up, we are displacing from HFC-134a to R-600a and it is worth discussing how calculations work when operating across multiple substances. When using volume-based caps (0 kg), we are determining how much volume of HFC-134a is lost and then translating that to the same number of kilograms of volume in R-600a. However, when we use units-based caps (0 units), we are determining how many new units of equipment are lost in HFC-134a and then adding that number of units to R-600a. The former doesn't result in the same number of units lost in HFC-134a being added to R-600a just as the later doesn't result in the same number of kilograms lost being added to R-600a. This is because their equipment initial charges are different! In other words, when doing calculations in units, units are translated. However, when doing calculations in volumes (kg or mt), volumes are translated.
 
 ## Displacement Type Considerations

--- a/docs/guide/md/tutorial_09.md
+++ b/docs/guide/md/tutorial_09.md
@@ -77,17 +77,6 @@ You should now see your baseline simulation running.
 
 This view shows HFC-134a as the dominant refrigerant.
 
-<video
-  src="/webm/tutorial_09_01.webm"
-  loop
-  muted
-  playsinline
-  controls
-  style="width: 500px; border: 2px solid #505050; border-radius: 3px;"
->
-  Your browser does not support the video tag. Please upgrade to a modern browser.
-</video>
-
 ## Adding the GWP Reduction Policy
 
 Now let's create a policy that gradually replaces HFC-134a consumption with R-600a. This will demonstrate how a substance substitution policy can reduce overall climate impact.
@@ -107,17 +96,6 @@ Now let's create a policy that gradually replaces HFC-134a consumption with R-60
 
 This policy will progressively reduce HFC-134a consumption by 10% each year starting in 2028, with that demand being met by R-600a instead. Over time, this creates a significant shift in the refrigerant mix while maintaining overall service levels.
 
-<video
-  src="/webm/tutorial_09_02.webm"
-  loop
-  muted
-  playsinline
-  controls
-  style="width: 500px; border: 2px solid #505050; border-radius: 3px;"
->
-  Your browser does not support the video tag. Please upgrade to a modern browser.
-</video>
-
 ## Creating the Simulation
 
 Now let's create a simulation to compare the policy scenario with our business-as-usual baseline.
@@ -129,17 +107,6 @@ Now let's create a simulation to compare the policy scenario with our business-a
 - Click **Finish**.
 
 You should now see both your **BAU** and **Replacement** scenarios displayed side by side in the results panel.
-
-<video
-  src="/webm/tutorial_09_03.webm"
-  loop
-  muted
-  playsinline
-  controls
-  style="width: 500px; border: 2px solid #505050; border-radius: 3px;"
->
-  Your browser does not support the video tag. Please upgrade to a modern browser.
-</video>
 
 ## Results
 
@@ -160,17 +127,6 @@ The dramatic emissions reduction demonstrates the power of GWP-focused policies.
 - Ensure **mt/ year** is selected.
 
 Indeed, despite the reduction in GWP, the overall consumption remains unchanged.
-
-<video
-  src="/webm/tutorial_09_04.webm"
-  loop
-  muted
-  playsinline
-  controls
-  style="width: 500px; border: 2px solid #505050; border-radius: 3px;"
->
-  Your browser does not support the video tag. Please upgrade to a modern browser.
-</video>
 
 ## Conclusion
 

--- a/docs/guide/md/tutorial_10.md
+++ b/docs/guide/md/tutorial_10.md
@@ -55,17 +55,6 @@ Let's create our baseline scenario with both high-energy and low-energy models o
 
 You should now see your baseline simulation running. We expect that the high-energy model is the dominant equipment with much higher consumption volumes than the low-energy alternative. To see this, select the **Bank** and **Equipment** radio buttons (make sure **All** is selected in the equipment panel). With the specific values we entered, given the production numbers and recharge demands, there is a very slight decrease in high energy equipment over time and a gradual increase in low energy. However, overall population is increasing. Switch to **GWh / year** to see energy.
 
-<video
-  src="/webm/tutorial_10_01.webm"
-  loop
-  muted
-  playsinline
-  controls
-  style="width: 500px; border: 2px solid #505050; border-radius: 3px;"
->
-  Your browser does not support the video tag. Please upgrade to a modern browser.
-</video>
-
 ## Adding the Energy Efficiency Policy
 
 Now let's create a policy that accelerates this replacement of high-energy equipment consumption with low-energy models. This will demonstrate how an equipment efficiency policy can reduce overall energy consumption without changing refrigerant type.
@@ -86,17 +75,6 @@ Now let's create a policy that accelerates this replacement of high-energy equip
 
 This policy will progressively reduce high-energy equipment consumption relative to the BAU. Specifically, we change 20% of high energy sales each year starting in 2028 with that demand being met by low-energy equipment instead. This accelerates that change we saw earlier. However, before we can see the effects, we need to make an additional simulation.
 
-<video
-  src="/webm/tutorial_10_02.webm"
-  loop
-  muted
-  playsinline
-  controls
-  style="width: 500px; border: 2px solid #505050; border-radius: 3px;"
->
-  Your browser does not support the video tag. Please upgrade to a modern browser.
-</video>
-
 ## Creating the Simulation
 
 Next, let's create a simulation to compare the policy scenario with our business-as-usual baseline.
@@ -108,17 +86,6 @@ Next, let's create a simulation to compare the policy scenario with our business
 - Click **Finish**
 
 Kigali Sim is now simulating both options but we need to configure the visualizations to do a comparison.
-
-<video
-  src="/webm/tutorial_10_03.webm"
-  loop
-  muted
-  playsinline
-  controls
-  style="width: 500px; border: 2px solid #505050; border-radius: 3px;"
->
-  Your browser does not support the video tag. Please upgrade to a modern browser.
-</video>
 
 ## Results
 
@@ -139,17 +106,6 @@ Compare the **BAU** and **Efficiency Policy** simulations and notice how overall
 - To better see the results, change **Absolute Value** to **Relative to BAU**
 
 Taken together, even though total equipment population and refrigerant consumption stay roughly constant, the overall kWh consumption drops substantially. This is because we're replacing equipment that consumes 500 kWh/year with units that consume only 350 kWh/year.
-
-<video
-  src="/webm/tutorial_10_04.webm"
-  loop
-  muted
-  playsinline
-  controls
-  style="width: 500px; border: 2px solid #505050; border-radius: 3px;"
->
-  Your browser does not support the video tag. Please upgrade to a modern browser.
-</video>
 
 ## Conclusion
 


### PR DESCRIPTION
Remove `<video>` tags from 11 tutorial markdown files (tutorial_02 through tutorial_10) as these embedded HTML elements are not appropriate for plain markdown contexts. 38 video blocks removed in total.