### PR TITLE
Add ai-info CLI command with llms.txt resource links

### DIFF
--- a/engine/src/main/java/org/kigalisim/KigaliSimCommander.java
+++ b/engine/src/main/java/org/kigalisim/KigaliSimCommander.java
@@ -6,6 +6,7 @@
 
 package org.kigalisim;
 
+import org.kigalisim.command.AiInfoCommand;
 import org.kigalisim.command.RunCommand;
 import org.kigalisim.command.ValidateCommand;
 import org.kigalisim.command.VersionCommand;
@@ -26,6 +27,7 @@ import picocli.CommandLine;
     version = "0.0.1",
     description = "KigaliSim command line interface",
     subcommands = {
+        AiInfoCommand.class,
         VersionCommand.class,
         RunCommand.class,
         ValidateCommand.class

--- a/engine/src/main/java/org/kigalisim/command/AiInfoCommand.java
+++ b/engine/src/main/java/org/kigalisim/command/AiInfoCommand.java
@@ -1,0 +1,42 @@
+/**
+ * Command to display AI / LLM resource information for Kigali Sim.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.kigalisim.command;
+
+import picocli.CommandLine.Command;
+
+/**
+ * Command to display information about Kigali Sim resources intended for AI assistants and LLMs.
+ */
+@Command(
+    name = "ai-info",
+    description = "Display LLM / AI assistant resource information for Kigali Sim",
+    mixinStandardHelpOptions = true
+)
+public class AiInfoCommand implements Runnable {
+
+  /**
+   * Constructs a new AiInfoCommand.
+   */
+  public AiInfoCommand() {
+  }
+
+  /**
+   * Executes the ai-info command by printing LLM resource URLs.
+   */
+  @Override
+  public void run() {
+    System.out.println("Additional information about Kigali Sim and how to use it is available");
+    System.out.println("at the following URLs geared specifically to AI / LLMs as an importable");
+    System.out.println("skill using the llms.txt protocol:");
+    System.out.println();
+    System.out.println("  Comprehensive overview:");
+    System.out.println("    https://kigalisim.org/llms-full.txt");
+    System.out.println();
+    System.out.println("  Index into more targeted documentation:");
+    System.out.println("    https://kigalisim.org/llms.txt");
+  }
+}

--- a/engine/src/test/java/org/kigalisim/command/AiInfoCommandTest.java
+++ b/engine/src/test/java/org/kigalisim/command/AiInfoCommandTest.java
@@ -1,0 +1,26 @@
+/**
+ * Unit tests for the AiInfoCommand class.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.kigalisim.command;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the AiInfoCommand class.
+ */
+public class AiInfoCommandTest {
+
+  /**
+   * Test that AiInfoCommand can be constructed.
+   */
+  @Test
+  public void testAiInfoCommandConstruction() {
+    AiInfoCommand command = new AiInfoCommand();
+    assertNotNull(command, "AiInfoCommand should be constructable");
+  }
+}


### PR DESCRIPTION
Adds a new `ai-info` subcommand that prints the llms-full.txt and llms.txt URLs so AI assistants and LLMs can easily discover the importable skill documentation for Kigali Sim.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>