### PR TITLE
Fix text wrapping in AI designer dialog prompt code block

### DIFF
--- a/editor/style/style.css
+++ b/editor/style/style.css
@@ -1005,6 +1005,12 @@ dialog .checkbox-list label {
   font-weight: normal;
 }
 
+/* Wrap prompt code block in AI designer dialog */
+#ai-designer-dialog .prompt-code {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 /* Hide up-to-date message by default in update dialog */
 #up-to-date-message {
   display: none;


### PR DESCRIPTION
## Summary
Added CSS styling to properly wrap and display prompt code text in the AI designer dialog, preventing long lines from overflowing.

## Changes
- Added `white-space: pre-wrap` to preserve formatting while allowing wrapping
- Added `word-break: break-word` to break long words that exceed container width
- Applied styles to `#ai-designer-dialog .prompt-code` selector

## Details
This ensures that prompt code blocks in the AI designer dialog display correctly on smaller screens and don't cause horizontal overflow, while maintaining the readability of the code formatting.

https://claude.ai/code/session_01QbmDCFFzcT4AS4YHah8Txm