### PR TITLE
Citation fixes.

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -38,6 +38,7 @@
   pages     = "12332",
   month     =  sep,
   year      =  2019,
+  doi       = {10.1038/s41598-019-48625-z},
   copyright = "https://creativecommons.org/licenses/by/4.0",
   language  = "en"
 }
@@ -81,6 +82,7 @@
   pages     = "425--431",
   month     =  oct,
   year      =  2018,
+  doi       = {10.1016/j.crte.2018.09.002},
   language  = "en"
 }
 
@@ -120,6 +122,7 @@
   pages     = "10949--10954",
   month     =  jul,
   year      =  2009,
+  doi       = {10.1073/pnas.0902817106},
   language  = "en"
 }
 
@@ -424,11 +427,13 @@ url="https://doi.org/10.1007/979-8-8688-0351-2_12"
   note = {Accessed: October 24, 2025}
 }
 
-@book{oses,     
-    Author     =  {Augspurger, Tobias and Malliaraki, Eirini and Hopkins, Josh},    
-    Date-Added =  {2023-01-10},    
-    Title      =  {Open Source in Environmental Sustainability},    
-    Year       =  {2023}}
+@book{oses,
+    Author     =  {Augspurger, Tobias and Malliaraki, Eirini and Hopkins, Josh},
+    Date-Added =  {2023-01-10},
+    Title      =  {Open Source in Environmental Sustainability},
+    Year       =  {2023},
+    doi        =  {10.5281/zenodo.7771632},
+    url        =  {https://report.opensustain.tech/chapters/index.html}}
 
 @misc{article5,
   title={Montreal Protocol on Substances that Deplete the Ozone Layer, Article 5: Special Situation of Developing Countries},


### PR DESCRIPTION
Closes #758. Makes two modifications:

 - It appears there was an issue with URL escaping for `Preparation of Kigali HFC Implementation Plans`.
 - 4 DOIs were accidentally left off.

My apologies for the inconvenience. Part of https://github.com/openjournals/joss-reviews/issues/10104.