### PR TITLE
Fix Chart.js import by switching to UMD build on cdnjs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -288,6 +288,9 @@ jobs:
       - name: Run unit tests
         run: pnpm exec grunt
         working-directory: ./editor
+      - name: Smoke test IDE for JS errors
+        run: node support/smoke_ide.js
+        working-directory: ./editor
   generateJavadoc:
     environment: build
     runs-on: ubuntu-latest

--- a/editor/support/dep_hashes.json
+++ b/editor/support/dep_hashes.json
@@ -48,9 +48,9 @@
       "sha256": "f3f59632b6c897f8f6fe2803b730ec42758aa2e89aa314f388031c57eb98b14c"
     },
     "third_party/chart.min.js": {
-      "url": "https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.5.0/chart.min.js",
+      "url": "https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.5.0/chart.umd.min.js",
       "version": "4.5.0",
-      "sha256": "bf8374840088264cb8b56c4abbe74694d63777c7dba5153c0b855855027c21b8"
+      "sha256": "2f27bcf471b2d69dd78494f6e2172fb28470eb843820e2f96bb85d39f9618d30"
     },
     "third_party/tabby-ui.min.css": {
       "url": "https://cdnjs.cloudflare.com/ajax/libs/tabby/12.0.3/css/tabby-ui.min.css",

--- a/editor/support/install_deps.sh
+++ b/editor/support/install_deps.sh
@@ -22,7 +22,7 @@ fi
 [ ! -e third_party/ext-options.js ] && wget https://cdnjs.cloudflare.com/ajax/libs/ace/1.36.2/ext-options.js -O third_party/ext-options.js
 [ ! -e third_party/ext-prompt.js ] && wget https://cdnjs.cloudflare.com/ajax/libs/ace/1.36.2/ext-prompt.js -O third_party/ext-prompt.js
 [ ! -e third_party/ext-language_tools.js ] && wget https://cdnjs.cloudflare.com/ajax/libs/ace/1.36.2/ext-language_tools.js -O third_party/ext-language_tools.js
-[ ! -e third_party/chart.min.js ] && wget https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.5.0/chart.min.js -O third_party/chart.min.js
+[ ! -e third_party/chart.min.js ] && wget https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.5.0/chart.umd.min.js -O third_party/chart.min.js
 [ ! -e third_party/tabby-ui.min.css ] && wget https://cdnjs.cloudflare.com/ajax/libs/tabby/12.0.3/css/tabby-ui.min.css -O third_party/tabby-ui.min.css
 [ ! -e third_party/tabby.min.js ] && wget https://cdnjs.cloudflare.com/ajax/libs/tabby/12.0.3/js/tabby.min.js -O third_party/tabby.min.js
 [ ! -e third_party/prism-tomorrow.min.css ] && wget https://cdnjs.cloudflare.com/ajax/libs/prism/1.30.0/themes/prism-tomorrow.min.css -O third_party/prism-tomorrow.min.css

--- a/editor/support/smoke_ide.js
+++ b/editor/support/smoke_ide.js
@@ -1,0 +1,107 @@
+/**
+ * Smoke test that opens the IDE in headless Chrome and checks for JS errors.
+ *
+ * Launches a local HTTP server, navigates Puppeteer to index.html, and
+ * listens for uncaught exceptions (pageerror) for a short window. Exits
+ * with code 1 if any errors are detected.
+ *
+ * Usage: node support/smoke_ide.js
+ *
+ * @license BSD, see LICENSE.md.
+ */
+
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+const puppeteer = require("puppeteer");
+const {execSync} = require("child_process");
+
+const PORT = 8089;
+const WAIT_MS = 10000;
+
+const MIME_TYPES = {
+  ".html": "text/html",
+  ".js": "text/javascript",
+  ".css": "text/css",
+  ".json": "application/json",
+  ".wasm": "application/wasm",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+  ".webm": "video/webm",
+};
+
+function startServer(root) {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      const urlPath = req.url.split("?")[0];
+      const filePath = path.join(root, urlPath === "/" ? "index.html" : urlPath);
+
+      fs.readFile(filePath, (err, data) => {
+        if (err) {
+          res.writeHead(404);
+          res.end("Not found");
+          return;
+        }
+        const ext = path.extname(filePath);
+        const contentType = MIME_TYPES[ext] || "application/octet-stream";
+        res.writeHead(200, {"Content-Type": contentType});
+        res.end(data);
+      });
+    });
+
+    server.listen(PORT, () => resolve(server));
+  });
+}
+
+async function main() {
+  const editorRoot = path.resolve(__dirname, "..");
+  const server = await startServer(editorRoot);
+
+  let chromiumPath = null;
+  try {
+    chromiumPath = execSync("which chromium", {encoding: "utf8"}).trim();
+  } catch (e) {
+    // Fall back to Puppeteer bundled browser.
+  }
+
+  const launchOptions = {
+    headless: "new",
+    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+  };
+  if (chromiumPath) {
+    launchOptions.executablePath = chromiumPath;
+  }
+
+  const browser = await puppeteer.launch(launchOptions);
+  const page = await browser.newPage();
+
+  const errors = [];
+
+  page.on("pageerror", (err) => {
+    errors.push(err.message);
+  });
+
+  console.log(`Opening IDE at http://localhost:${PORT} ...`);
+  await page.goto(`http://localhost:${PORT}/index.html`, {
+    waitUntil: "domcontentloaded",
+  });
+
+  console.log(`Waiting ${WAIT_MS / 1000} seconds for errors...`);
+  await new Promise((resolve) => setTimeout(resolve, WAIT_MS));
+
+  await browser.close();
+  server.close();
+
+  if (errors.length > 0) {
+    console.error(`\nFAILED: ${errors.length} uncaught error(s) detected:\n`);
+    errors.forEach((msg, i) => console.error(`  ${i + 1}. ${msg}`));
+    process.exit(1);
+  } else {
+    console.log("\nPASSED: No uncaught errors detected.");
+  }
+}
+
+main().catch((err) => {
+  console.error("Smoke test crashed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
The supply-chain pinning commit (5b66357) migrated Chart.js from
jsdelivr to cdnjs but used chart.min.js which is the ESM build.
ESM builds use export syntax and do not expose Chart as a global,
causing "Chart is not defined" when loaded via a regular script tag.
Switch to chart.umd.min.js which is the UMD build that correctly
defines the Chart global. Update dep_hashes.json with the matching
SHA256 hash.

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_0171LS9AX2PEccQG3A2usL7e