### PR TITLE
Add the virgin keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ All the automated checks and development operations described below work in the 
 - ECMAScript / JavaScript testing: `cd editor && pnpm exec grunt`
 - Build and run the UI-based editor locally: `cd editor && bash ./support/make.sh && python3 -m http.server`
 
+Note that, to run front-end tests, you may need to first `bash ./support/make.sh`.
+
 ### Other Local Setup
 To run this system locally outside a dev container, please:
 

--- a/beta_changelog.md
+++ b/beta_changelog.md
@@ -14,6 +14,14 @@ Finally, we want to again express our gratitude for your feedback and time.
 
 The following changes have been adopted and released.
 
+### Virgin keyword
+
+**Status**: Released June 11, 2026
+
+**Classification**: Enhancement
+
+Previously one could refer to all `sales` (primary + secondary) or individual streams (`domestic`, `import`). The new `virgin` keyword lets one refer to just primary production without recycling.
+
 ### April 2026 Outage
 
 **Status**: Started April 10, resolved April 14 (2026)

--- a/docs/guide/glossary.html
+++ b/docs/guide/glossary.html
@@ -182,9 +182,6 @@
           <dt>Sales</dt>
           <dd>A stream representing all consumption within the simulated country in the current year. In other words, the total new substance entering the market. For all simulations, this is the combination of both domestic manufacturing and imports. However, this includes recycling if active. Set / change sales impacts all consumption where, as recycling is limited by the recover command, domestic and import will be modified to satisfy a set or change after taking the unchanged recycling capacity into account. Cap / floor using sales place upper or lower limits on all consumption where those limits include recycling.</dd>
 
-          <dt>Virgin</dt>
-          <dd>A stream representing domestic and import consumption only, excluding recycling and exports. This is a meta-stream similar to sales but without secondary (recycled) material. Set / change virgin impacts domestic and import proportionally without subtracting recycling. Cap / floor using virgin place upper or lower limits on domestic and import only. Recycling is bound by amount captured through the recover command.</dd>
-
           <dt>Scrap Rate</dt>
           <dd>See Retirement Rate.</dd>
 
@@ -211,6 +208,9 @@
 
           <dt>UI-based Editor</dt>
           <dd>UI-based point-and-click interface for building simulations without writing code. Also called the Designer or UI Editor.</dd>
+
+          <dt>Virgin</dt>
+          <dd>A stream representing domestic and import consumption only, excluding recycling and exports. This is a meta-stream similar to sales but without secondary (recycled) material. Set / change virgin impacts domestic and import proportionally without subtracting recycling. Cap / floor using virgin place upper or lower limits on domestic and import only. Recycling is bound by amount captured through the recover command.</dd>
 
           <dt>WASM</dt>
           <dd>WebAssembly. A binary instruction format that enables high-performance execution of code in web browsers. Kigali Sim's Java engine is compiled to WASM for browser-based execution.</dd>

--- a/docs/guide/glossary.html
+++ b/docs/guide/glossary.html
@@ -182,6 +182,9 @@
           <dt>Sales</dt>
           <dd>A stream representing all consumption within the simulated country in the current year. In other words, the total new substance entering the market. For all simulations, this is the combination of both domestic manufacturing and imports. However, this includes recycling if active. Set / change sales impacts all consumption where, as recycling is limited by the recover command, domestic and import will be modified to satisfy a set or change after taking the unchanged recycling capacity into account. Cap / floor using sales place upper or lower limits on all consumption where those limits include recycling.</dd>
 
+          <dt>Virgin</dt>
+          <dd>A stream representing domestic and import consumption only, excluding recycling and exports. This is a meta-stream similar to sales but without secondary (recycled) material. Set / change virgin impacts domestic and import proportionally without subtracting recycling. Cap / floor using virgin place upper or lower limits on domestic and import only. Recycling is bound by amount captured through the recover command.</dd>
+
           <dt>Scrap Rate</dt>
           <dd>See Retirement Rate.</dd>
 
@@ -195,7 +198,7 @@
           <dd>A modeling approach used in system design / analysis that tracks both stocks (accumulated quantities like equipment population or substance banks) and flows (rates of change like sales, emissions, or retirement) over time.</dd>
 
           <dt>Stream</dt>
-          <dd>A time series of values in the simulation representing different types of flows or stocks. Available streams include domestic, import, export, sales, equipment, priorEquipment, bank, and age.</dd>
+          <dd>A time series of values in the simulation representing different types of flows or stocks. Available streams include domestic, import, export, sales, virgin, equipment, priorEquipment, bank, and age.</dd>
 
           <dt>Substance</dt>
           <dd>A chemical refrigerant or other controlled substance used in applications, such as HFC-134a, R-410A, R-600a, or HFC-32. Defined using <code>uses substance "name"</code> within applications.</dd>

--- a/docs/guide/qubectalk-prism.js
+++ b/docs/guide/qubectalk-prism.js
@@ -27,7 +27,7 @@ Prism.languages.qubectalk = {
       "uniformly", "limit", "annually", "beginning", "day", "days",
       "each", "month", "months", "onwards", "year", "years", "yr", "yrs", "unit",
       "units", "kg", "mt", "tCO2e", "kgCO2e", "kwh", "priorEquipment", "equipment",
-      "export", "import", "domestic", "sales", "mean",
+      "export", "import", "domestic", "sales", "virgin", "mean",
     ].join("|") + ")\\b"),
     greedy: true,
   },

--- a/docs/guide/qubectalk_commands.html
+++ b/docs/guide/qubectalk_commands.html
@@ -44,7 +44,7 @@
 
         <p><strong>Syntax:</strong> <code>assume [no|only recharge|continued] streamName during years startYear to endYear</code></p>
 
-        <p><strong>Available Streams:</strong> domestic, import, export, sales, bank, equipment</p>
+        <p><strong>Available Streams:</strong> domestic, import, export, sales, virgin, bank, equipment</p>
 
         <p><strong>Examples:</strong></p>
         <pre><code class="language-qubectalk">assume no domestic during year 2030
@@ -196,7 +196,7 @@ floor import to 100 units displacing by units "R-600a" during years 2028 to 2032
 
         <p><strong>Available Streams:</strong></p>
         <ul>
-          <li><code>sales</code>, <code>domestic</code>, <code>import</code>, <code>export</code> - Sales and trade volumes</li>
+          <li><code>sales</code>, <code>virgin</code>, <code>domestic</code>, <code>import</code>, <code>export</code> - Sales and trade volumes</li>
           <li><code>equipment</code>, <code>priorEquipment</code>, <code>bank</code> - Equipment population</li>
           <li><code>age</code> - Weighted average equipment age (read-only, Advanced Editor only)</li>
         </ul>

--- a/docs/guide/tutorial_04.html
+++ b/docs/guide/tutorial_04.html
@@ -98,7 +98,7 @@
             This refers to all consumption in the country. So, having Kigali Sim set / change sales impacts overall consumption. More specifically, it includes domestic and import but excludes export. When applying changes through the sales keyword, Kigali Sim will try to keep the ratio between domestic and import the same for the substance.
           </p>
           <p>
-            Note that this may also include "secondary" substance if recycling is active. That said, indicated by the recover command, recycling capacity is assumed to be limited. So, domestic and import will be modified to satisfy a set or change command after taking the unchanged recycling stream into account. However, using sales with cap/floor (like for permitting) places lower or upper limits on all consumption including recycling. For virgin only, replace sales with individual commands on domestic and import. This will exclude secondary production.
+            Note that this may also include "secondary" substance if recycling is active. That said, indicated by the recover command, recycling capacity is assumed to be limited. So, domestic and import will be modified to satisfy a set or change command after taking the unchanged recycling stream into account. However, using sales with cap/floor (like for permitting) places lower or upper limits on all consumption including recycling. For virgin only, use the <code>virgin</code> keyword which includes domestic and import but excludes secondary. Alternatively, replace sales with individual commands on domestic and import. This will exclude secondary production.
           </p>
         </details>
 

--- a/docs/guide/tutorial_04a.html
+++ b/docs/guide/tutorial_04a.html
@@ -120,7 +120,7 @@
             This refers to all consumption in the country. So, having Kigali Sim set / change sales impacts overall consumption. More specifically, it includes domestic and import but excludes export. When applying changes through the sales keyword, Kigali Sim will try to keep the ratio between domestic and import the same for the substance.
           </p>
           <p>
-            Note that this may also include "secondary" substance if recycling is active. That said, indicated by the recover command, recycling capacity is assumed to be limited. So, domestic and import will be modified to satisfy a set or change command after taking the unchanged recycling stream into account. However, using sales with cap/floor (like for permitting) places lower or upper limits on all consumption including recycling. For virgin only, replace sales with individual commands on domestic and import. This will exclude secondary production.
+            Note that this may also include "secondary" substance if recycling is active. That said, indicated by the recover command, recycling capacity is assumed to be limited. So, domestic and import will be modified to satisfy a set or change command after taking the unchanged recycling stream into account. However, using sales with cap/floor (like for permitting) places lower or upper limits on all consumption including recycling. For virgin only, use the <code>virgin</code> keyword which includes domestic and import but excludes secondary. Alternatively, replace sales with individual commands on domestic and import. This will exclude secondary production.
           </p>
         </details>
       </section>

--- a/docs/spec/qubectalk.md
+++ b/docs/spec/qubectalk.md
@@ -1,8 +1,8 @@
 ---
 title: QubecTalk Domain Specific Language
 author: A Samuel Pottinger
-date: 2025-10-30
-version: 1.1
+date: 2026-06-11
+version: 1.2
 ---
 
 **Summary**: Modelers may engage with a domain specific language called QubecTalk in order to construct analyses relevant to the Montreal Protocol and Kigali Amendment. Specifically, this human-readable text-based format can describe scenarios to a simulation engine called Kigali Sim. Written in JavaScript with an ANTLR4 parser, the interpreter for this DSL can execute in browser via WebAssembly or locally on a machine using Java (Temurin 21+). It may run as part of a web application with both a graphical user interface (Designer tab) and code editor (Advanced Editor tab). However, it may also be invoked directly through a command line JAR interface or Docker. Additionally, these programs can be written "manually" within a code editor or through a graphical user interface (which does not require authors to engage code directly). This document describes QubecTalk version 2.0 and offers realistic full featured examples of simulations written in the language.
@@ -169,7 +169,7 @@ If no stream is specified, it will apply proportionally across sub-streams (dome
  - `set` / `change` sales impacts all consumption but recycling is limited by the addressable stream as indicated in a `recover` command so domestic and import will be modified to satisfy new target levels with the same level of prior recycling.
  - `cap` / `floor` place lower or upper limits on all consumption including recycling.
 
- For virgin only, use the `virgin` keyword which includes domestic and import but excludes secondary, or replace `sales` with individual commands on `domestic` and `import` to exclude secondary.
+ For virgin only, use the `virgin` keyword which includes domestic and import but excludes secondary. Alternatively, replace `sales` with individual commands on `domestic` and `import` to exclude secondary.
 
 **Virgin keyword**: The `virgin` keyword indicates domestic and import consumption only, excluding recycling and exports. Unlike `sales`, virgin does not include secondary (recycled) material.
 

--- a/docs/spec/qubectalk.md
+++ b/docs/spec/qubectalk.md
@@ -115,7 +115,7 @@ initial charge with 0.10 kg / unit for export
 If this is omitted and the substance has sales, an error message may be shown. The initial charge determines how much substance is contained in each unit of new equipment for that stream.
 
 ### Sales
-The sale of substances typically defines the equipment population. QubecTalk considers possible streams to fit into `domestic`, `import`, `export`, or `recycling`.
+The sale of substances typically defines the equipment population. QubecTalk considers possible streams to fit into `domestic`, `import`, `export`, `virgin`, or `recycling`.
 
 **Enable Statement**: Before setting sales values, streams must be explicitly enabled using the `enable` command. This command indicates which streams (domestic, import, export) will be used for a substance:
 
@@ -169,7 +169,13 @@ If no stream is specified, it will apply proportionally across sub-streams (dome
  - `set` / `change` sales impacts all consumption but recycling is limited by the addressable stream as indicated in a `recover` command so domestic and import will be modified to satisfy new target levels with the same level of prior recycling.
  - `cap` / `floor` place lower or upper limits on all consumption including recycling.
 
-For virgin only, replace `sales` with individual commands on `domestic` and `import` to exclude secondary.
+ For virgin only, use the `virgin` keyword which includes domestic and import but excludes secondary, or replace `sales` with individual commands on `domestic` and `import` to exclude secondary.
+
+**Virgin keyword**: The `virgin` keyword indicates domestic and import consumption only, excluding recycling and exports. Unlike `sales`, virgin does not include secondary (recycled) material.
+
+ - `set` / `change` virgin impacts domestic and import proportionally without subtracting recycling.
+ - `cap` / `floor` place lower or upper limits on domestic and import only (excluding recycling).
+ - Recycling is bound by amount captured through the `recover` command.
 
 ### Population
 Historic equipment populations are typically inferred by sales before applying a retirement rate into the future. However, they may be specified manually as well.
@@ -278,7 +284,7 @@ cap import to 750 mt during years 4 to 5
 cap domestic to 0 mt during years 10 to onwards
 ```
 
-Sales, domestic, import, export, and equipment streams can accept the cap. If specifying an aggregate stream, it will be applied proportionally. For example, for sales, the effect will be split proportionally between domestic and imports.
+Sales, virgin, domestic, import, export, and equipment streams can accept the cap. If specifying an aggregate stream, it will be applied proportionally. For example, for sales, the effect will be split proportionally between domestic and imports. For virgin, the effect will be split proportionally between domestic and import without subtracting recycling.
 
 When using units (equipment) in cap commands, those limits apply after recharge calculations. So a cap of 100 units means 100 units of new equipment on top of recharge needs for prior equipment.
 
@@ -338,7 +344,7 @@ recover 20 % with 80 % reuse with default induction # Use system default
   - Units-based specs: Default 0% induction (displacement behavior)
   - Non-units specs (kg/mt): Default 100% induction (induced demand behavior)
 
-**100% induction is recommended for users who are uncertain** as induction is a complex economic phenomenon. It can be paired with other policies like caps on virgin material to ensure desired reductions.
+**100% induction is recommended for users who are uncertain** as induction is a complex economic phenomenon. It can be paired with other policies like caps on the `virgin` stream (domestic + import) to ensure desired reductions.
 
 The `displacing` clause can also be used to specify which substance or stream is offset:
 
@@ -368,7 +374,7 @@ assume no import during years 5 to 10
 assume only recharge bank during years 3 to onwards
 ```
 
-Supported streams: `domestic`, `import`, `export`, `sales`, `bank`, `equipment`
+Supported streams: `domestic`, `import`, `export`, `sales`, `virgin`, `bank`, `equipment`
 
 The `assume only recharge` variant is particularly useful when modeling that new equipment sales should cease but servicing continues.
 
@@ -521,7 +527,7 @@ define salesOther as get sales of "HFC-134a" as kg
 define equipmentCount as get equipment as units
 ```
 
-Setting an aggregate stream like sales will cause the value to be distributed proportionally to the prior value of the sub-streams. In the case of this example, this would be applied across import, domestic, and export.
+Setting an aggregate stream like sales will cause the value to be distributed proportionally to the prior value of the sub-streams. In the case of this example, this would be applied across import, domestic, and export. For `virgin`, the value is distributed proportionally across domestic and import without subtracting recycling.
 
 ### Age stream
 The `age` stream provides access to the weighted average age of equipment in the population. This is a read-only computed stream:
@@ -605,6 +611,7 @@ While the system can operate with constraints through `cap` and `floor`, updates
 | **Trigger**                 | **Sales**                                       | **Consumption**                        | **Population**                                                                                  |
 | ------------------------------------------------------ | ----------------------------------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------- |
 | Sales (domestic, import, export) | Changed directly                                | Recalc using equals value              | Recalc new and total equip after subtract recharge and recycle, retiring at recharge if needed. |
+| Virgin (domestic, import) | Changed directly (without recycling subtraction)                               | Recalc using equals value              | Recalc new and total equip after subtract recharge and recycle, retiring at recharge if needed. |
 | Consumption                   | Recalc after add recharge and subtract recycle. | Changed directly                     | Recalc new and total equip after subtract recharge and recycle, retiring at recharge if needed. |
 | Population (equipment)      | Recalc after add recharge and subtract recycle. | Recalc after sales update using equals | New equip and total current equip changes but prior equip untouched.                            |
 | Population (priorEquipment) | No change                                       | No change                            | Change prior equip. New and total equipment recalculated.                                       |

--- a/editor/index.html
+++ b/editor/index.html
@@ -1522,10 +1522,10 @@
         <span class="sel long">
           <select class="set-target-input" aria-label="Target for set command">
             <option value="sales">all sales</option>
-            <option value="virgin">virgin sales</option>
             <option value="domestic">domestic (virgin)</option>
             <option value="import">import</option>
             <option value="export">export</option>
+            <option value="virgin">all virgin sales</option>
             <option value="equipment">equipment</option>
             <option value="priorEquipment">prior equipment</option>
             <option value="bank">bank</option>
@@ -1593,7 +1593,7 @@
                 <option value="domestic">domestic (virgin)</option>
                 <option value="import">import</option>
                 <option value="export">export</option>
-                <option value="virgin">virgin sales</option>
+                <option value="virgin">all virgin sales</option>
                 <option value="equipment">equipment</option>
                 <option value="priorEquipment">prior equipment</option>
                 <option value="bank">bank</option>
@@ -1672,7 +1672,7 @@
             <option value="domestic">domestic (virgin)</option>
             <option value="import">import</option>
             <option value="export">export</option>
-            <option value="virgin">virgin sales</option>
+            <option value="virgin">all virgin sales</option>
             <option value="equipment">equipment</option>
             <option value="priorEquipment">prior equipment</option>
             <option value="bank">bank</option>
@@ -1729,7 +1729,7 @@
             <option value="domestic">domestic (virgin)</option>
             <option value="import">import</option>
             <option value="export">export</option>
-            <option value="virgin">virgin sales</option>
+            <option value="virgin">all virgin sales</option>
             <option value="equipment">equipment</option>
               <option value="priorEquipment">prior equipment</option>
               <option value="bank">bank</option>
@@ -1851,7 +1851,7 @@
               <option value="domestic">domestic (virgin)</option>
               <option value="import">import</option>
               <option value="export">export</option>
-              <option value="virgin">virgin sales</option>
+              <option value="virgin">all virgin sales</option>
               <option value="equipment">equipment</option>
                 <option value="priorEquipment">prior equipment</option>
                 <option value="bank">bank</option>
@@ -1921,7 +1921,7 @@
             <option value="domestic">domestic (virgin)</option>
             <option value="import">import</option>
             <option value="export">export</option>
-            <option value="virgin">virgin sales</option>
+            <option value="virgin">all virgin sales</option>
             <option value="equipment">equipment</option>
             <option value="priorEquipment">prior equipment</option>
             <option value="bank">bank</option>

--- a/editor/index.html
+++ b/editor/index.html
@@ -1522,6 +1522,7 @@
         <span class="sel long">
           <select class="set-target-input" aria-label="Target for set command">
             <option value="sales">all sales</option>
+            <option value="virgin">virgin sales</option>
             <option value="domestic">domestic (virgin)</option>
             <option value="import">import</option>
             <option value="export">export</option>
@@ -1589,6 +1590,7 @@
             <span class="sel long">
               <select class="change-target-input" aria-label="Target for change command">
                 <option value="sales">all sales</option>
+                <option value="virgin">virgin sales</option>
                 <option value="domestic">domestic (virgin)</option>
                 <option value="import">import</option>
                 <option value="export">export</option>
@@ -1667,6 +1669,7 @@
         <span class="sel long">
           <select class="limit-target-input" aria-label="Target for limit command">
             <option value="sales">all sales</option>
+            <option value="virgin">virgin sales</option>
             <option value="domestic">domestic (virgin)</option>
             <option value="import">import</option>
             <option value="export">export</option>
@@ -1723,6 +1726,7 @@
             </optgroup>
             <optgroup label="Streams">
               <option value="sales">all sales</option>
+              <option value="virgin">virgin sales</option>
               <option value="domestic">domestic (virgin)</option>
               <option value="import">import</option>
               <option value="export">export</option>
@@ -1844,6 +1848,7 @@
               </optgroup>
               <optgroup label="Streams">
                 <option value="sales">all sales</option>
+                <option value="virgin">virgin sales</option>
                 <option value="domestic">domestic (virgin)</option>
                 <option value="import">import</option>
                 <option value="export">export</option>
@@ -1913,6 +1918,7 @@
         <span class="sel long">
           <select class="replace-target-input" aria-label="Target for replace command">
             <option value="sales">all sales</option>
+            <option value="virgin">virgin sales</option>
             <option value="domestic">domestic (virgin)</option>
             <option value="import">import</option>
             <option value="export">export</option>

--- a/editor/index.html
+++ b/editor/index.html
@@ -1590,10 +1590,10 @@
             <span class="sel long">
               <select class="change-target-input" aria-label="Target for change command">
                 <option value="sales">all sales</option>
-                <option value="virgin">virgin sales</option>
                 <option value="domestic">domestic (virgin)</option>
                 <option value="import">import</option>
                 <option value="export">export</option>
+                <option value="virgin">virgin sales</option>
                 <option value="equipment">equipment</option>
                 <option value="priorEquipment">prior equipment</option>
                 <option value="bank">bank</option>
@@ -1669,10 +1669,10 @@
         <span class="sel long">
           <select class="limit-target-input" aria-label="Target for limit command">
             <option value="sales">all sales</option>
-            <option value="virgin">virgin sales</option>
             <option value="domestic">domestic (virgin)</option>
             <option value="import">import</option>
             <option value="export">export</option>
+            <option value="virgin">virgin sales</option>
             <option value="equipment">equipment</option>
             <option value="priorEquipment">prior equipment</option>
             <option value="bank">bank</option>
@@ -1725,12 +1725,12 @@
               <option value="">nothing</option>
             </optgroup>
             <optgroup label="Streams">
-              <option value="sales">all sales</option>
-              <option value="virgin">virgin sales</option>
-              <option value="domestic">domestic (virgin)</option>
-              <option value="import">import</option>
-              <option value="export">export</option>
-              <option value="equipment">equipment</option>
+            <option value="sales">all sales</option>
+            <option value="domestic">domestic (virgin)</option>
+            <option value="import">import</option>
+            <option value="export">export</option>
+            <option value="virgin">virgin sales</option>
+            <option value="equipment">equipment</option>
               <option value="priorEquipment">prior equipment</option>
               <option value="bank">bank</option>
               <option value="priorBank">prior bank</option>
@@ -1846,13 +1846,13 @@
               <optgroup label="None">
                 <option value="">nothing</option>
               </optgroup>
-              <optgroup label="Streams">
-                <option value="sales">all sales</option>
-                <option value="virgin">virgin sales</option>
-                <option value="domestic">domestic (virgin)</option>
-                <option value="import">import</option>
-                <option value="export">export</option>
-                <option value="equipment">equipment</option>
+            <optgroup label="Streams">
+              <option value="sales">all sales</option>
+              <option value="domestic">domestic (virgin)</option>
+              <option value="import">import</option>
+              <option value="export">export</option>
+              <option value="virgin">virgin sales</option>
+              <option value="equipment">equipment</option>
                 <option value="priorEquipment">prior equipment</option>
                 <option value="bank">bank</option>
                 <option value="priorBank">prior bank</option>
@@ -1918,10 +1918,10 @@
         <span class="sel long">
           <select class="replace-target-input" aria-label="Target for replace command">
             <option value="sales">all sales</option>
-            <option value="virgin">virgin sales</option>
             <option value="domestic">domestic (virgin)</option>
             <option value="import">import</option>
             <option value="export">export</option>
+            <option value="virgin">virgin sales</option>
             <option value="equipment">equipment</option>
             <option value="priorEquipment">prior equipment</option>
             <option value="bank">bank</option>

--- a/editor/js/ace-mode-qubectalk.js
+++ b/editor/js/ace-mode-qubectalk.js
@@ -20,8 +20,10 @@ ace.define("ace/mode/qubectalk", [
 
     const samplingKeywords = "mean|normally|sample|std|uniformly|limit";
 
-    const streams = "priorEquipment|equipment|priorBank|bank|export|import|domestic|sales|" +
-      "virgin|age";
+    const streams = [
+      "priorEquipment", "equipment", "priorBank", "bank", "export", "import",
+      "domestic", "sales", "virgin", "age",
+    ].join("|");
 
     const units = "annually|beginning|day|days|each|kg|kwh|month|months|mt|onwards|percent|" +
       "tCO2e|kgCO2e|unit|units|year|years|yr|yrs";

--- a/editor/js/ace-mode-qubectalk.js
+++ b/editor/js/ace-mode-qubectalk.js
@@ -20,7 +20,7 @@ ace.define("ace/mode/qubectalk", [
 
     const samplingKeywords = "mean|normally|sample|std|uniformly|limit";
 
-    const streams = "priorEquipment|equipment|priorBank|bank|export|import|domestic|sales|age";
+    const streams = "priorEquipment|equipment|priorBank|bank|export|import|domestic|sales|virgin|age";
 
     const units = "annually|beginning|day|days|each|kg|kwh|month|months|mt|onwards|percent|" +
       "tCO2e|kgCO2e|unit|units|year|years|yr|yrs";

--- a/editor/js/ace-mode-qubectalk.js
+++ b/editor/js/ace-mode-qubectalk.js
@@ -20,7 +20,8 @@ ace.define("ace/mode/qubectalk", [
 
     const samplingKeywords = "mean|normally|sample|std|uniformly|limit";
 
-    const streams = "priorEquipment|equipment|priorBank|bank|export|import|domestic|sales|virgin|age";
+    const streams = "priorEquipment|equipment|priorBank|bank|export|import|domestic|sales|" +
+      "virgin|age";
 
     const units = "annually|beginning|day|days|each|kg|kwh|month|months|mt|onwards|percent|" +
       "tCO2e|kgCO2e|unit|units|year|years|yr|yrs";

--- a/editor/js/engine_const.js
+++ b/editor/js/engine_const.js
@@ -13,6 +13,7 @@ const STREAM_BASE_UNITS = new Map();
 STREAM_BASE_UNITS.set("domestic", "kg");
 STREAM_BASE_UNITS.set("import", "kg");
 STREAM_BASE_UNITS.set("sales", "kg");
+STREAM_BASE_UNITS.set("virgin", "kg");
 STREAM_BASE_UNITS.set("energy", "kwh");
 STREAM_BASE_UNITS.set("recycle", "kg");
 STREAM_BASE_UNITS.set("consumption", "tCO2e");

--- a/editor/js/ui_editor_const.js
+++ b/editor/js/ui_editor_const.js
@@ -8,7 +8,7 @@
  * Stream types that are always available regardless of substance configuration.
  * @constant {Array<string>}
  */
-const ALWAYS_ON_STREAMS = ["sales", "equipment", "priorEquipment"];
+const ALWAYS_ON_STREAMS = ["sales", "virgin", "equipment", "priorEquipment"];
 
 /**
  * Command compatibility mapping to compatibility modes:

--- a/editor/test/test_integration.js
+++ b/editor/test/test_integration.js
@@ -1527,6 +1527,21 @@ function buildIntegrationTests() {
       ],
     );
 
+    buildTest("tests virgin stream set", "/examples/set_virgin.qta", [
+      (result, assert) => {
+        const record = getResult(result, "BAU", 1, 0, "Test", "SubA");
+        const domestic = record.getDomestic();
+        assert.closeTo(domestic.getValue(), 500, 0.0001);
+        assert.deepEqual(domestic.getUnits(), "kg");
+      },
+      (result, assert) => {
+        const record = getResult(result, "BAU", 1, 0, "Test", "SubA");
+        const importVal = record.getImport();
+        assert.closeTo(importVal.getValue(), 500, 0.0001);
+        assert.deepEqual(importVal.getUnits(), "kg");
+      },
+    ]);
+
     QUnit.test("preserves number formatting in code to UI to code round-trip", function (assert) {
       assert.expect(4);
 

--- a/editor/test/test_ui_translator_reverse.js
+++ b/editor/test/test_ui_translator_reverse.js
@@ -360,6 +360,85 @@ function buildUiTranslatorReverseTests() {
       assert.notEqual(code.indexOf('simulate "scenario"'), -1);
     });
 
+    QUnit.test("sets virgin values in substances", function (assert) {
+      const command = new Command("setVal", "virgin", new EngineNumber("10", "mt"), null);
+      const substance = createWithCommand("test", true, command);
+      const code = substance.toCode(0);
+      assert.notEqual(code.indexOf("set virgin to 10 mt"), -1);
+    });
+
+    QUnit.test("changes virgin values in substances", function (assert) {
+      const command = new Command(
+        "change",
+        "virgin",
+        new EngineNumber("+5", "% / year"),
+        null,
+      );
+      const substance = createWithCommand("test", true, command);
+      const code = substance.toCode(0);
+      assert.notEqual(code.indexOf("change virgin by +5 % / year"), -1);
+    });
+
+    QUnit.test("caps virgin values in substances", function (assert) {
+      const command = new LimitCommand(
+        "cap", "virgin", new EngineNumber(5, "mt"), null, null, "",
+      );
+      const substance = createWithCommand("test", true, command);
+      const code = substance.toCode(0);
+      assert.notEqual(code.indexOf("cap virgin to 5 mt"), -1);
+    });
+
+    QUnit.test("allows virgin in multiple set statements", function (assert) {
+      const commands = [
+        new Command("setVal", "domestic", new EngineNumber("1", "mt"), null),
+        new Command("setVal", "import", new EngineNumber("2", "mt"), null),
+        new Command("setVal", "virgin", new EngineNumber("3", "mt"), null),
+      ];
+      const substance = createWithCommands("test", false, commands);
+      assert.ok(substance.getIsCompatible());
+
+      if (substance.getIsCompatible()) {
+        const code = substance.toCode(0);
+        assert.notEqual(code.indexOf("set domestic to 1 mt"), -1);
+        assert.notEqual(code.indexOf("set import to 2 mt"), -1);
+        assert.notEqual(code.indexOf("set virgin to 3 mt"), -1);
+      }
+    });
+
+    QUnit.test("allows virgin in multiple change statements", function (assert) {
+      const commands = [
+        new Command("change", "domestic", new EngineNumber("+1", "mt / yr"), null),
+        new Command("change", "import", new EngineNumber("+2", "mt / yr"), null),
+        new Command("change", "virgin", new EngineNumber("+3", "mt / yr"), null),
+      ];
+      const substance = createWithCommands("test", false, commands);
+      assert.ok(substance.getIsCompatible());
+
+      if (substance.getIsCompatible()) {
+        const code = substance.toCode(0);
+        assert.notEqual(code.indexOf("change domestic by +1 mt / yr"), -1);
+        assert.notEqual(code.indexOf("change import by +2 mt / yr"), -1);
+        assert.notEqual(code.indexOf("change virgin by +3 mt / yr"), -1);
+      }
+    });
+
+    QUnit.test("allows virgin in initial charge statements", function (assert) {
+      const commands = [
+        new Command("initial charge", "domestic", new EngineNumber(1, "kg / unit"), null),
+        new Command("initial charge", "import", new EngineNumber(2, "kg / unit"), null),
+        new Command("initial charge", "virgin", new EngineNumber(3, "kg / unit"), null),
+      ];
+      const substance = createWithCommands("test", false, commands);
+      assert.ok(substance.getIsCompatible());
+
+      if (substance.getIsCompatible()) {
+        const code = substance.toCode(0);
+        assert.notEqual(code.indexOf("initial charge with 1 kg / unit for domestic"), -1);
+        assert.notEqual(code.indexOf("initial charge with 2 kg / unit for import"), -1);
+        assert.notEqual(code.indexOf("initial charge with 3 kg / unit for virgin"), -1);
+      }
+    });
+
     QUnit.test("allows multiple set statements", function (assert) {
       const commands = [
         new Command("setVal", "domestic", new EngineNumber("1", "mt"), null),

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = 'org.kigalisim'
-version = '0.1.8'
+version = '0.1.9'
 
 eclipse {
     classpath {
@@ -272,7 +272,7 @@ publishing {
       gpr(MavenPublication) {
         groupId = 'org.kigalisim'
         artifactId = 'engine'
-        version = '0.1.8'
+        version = '0.1.9'
 
         from(components.java)
         artifact fatJarVersion

--- a/engine/src/main/antlr/org/kigalisim/lang/QubecTalk.g4
+++ b/engine/src/main/antlr/org/kigalisim/lang/QubecTalk.g4
@@ -238,6 +238,8 @@ DOMESTIC_: 'domestic';
 
 SALES_: 'sales';
 
+VIRGIN_: 'virgin';
+
 AGE_: 'age';
 
 /**
@@ -362,7 +364,7 @@ expression: number  # simpleExpression
  * -----------------
  **/
 
-stream: (PRIOR_EQUIPMENT_ | EQUIPMENT_ | BANK_ | PRIOR_BANK_ | EXPORT_ | IMPORT_ | DOMESTIC_ | SALES_ | AGE_);
+stream: (PRIOR_EQUIPMENT_ | EQUIPMENT_ | BANK_ | PRIOR_BANK_ | EXPORT_ | IMPORT_ | DOMESTIC_ | SALES_ | VIRGIN_ | AGE_);
 
 identifier: IDENTIFIER_  # identifierAsVar;
 

--- a/engine/src/main/java/org/kigalisim/engine/SingleThreadEngine.java
+++ b/engine/src/main/java/org/kigalisim/engine/SingleThreadEngine.java
@@ -264,6 +264,11 @@ public class SingleThreadEngine implements Engine {
         SetExecutor setExecutor = new SetExecutor(this);
         setExecutor.handleSalesSet(scope, name, value, yearMatcher);
       }
+      case "virgin" -> {
+        simulationState.clearLastSpecifiedValue(scope, name);
+        SetExecutor setExecutor = new SetExecutor(this);
+        setExecutor.handleVirginSet(scope, name, value, yearMatcher);
+      }
       default -> {
         if (EngineSupportUtils.isSalesSubstream(name)) {
           simulationState.clearLastSpecifiedValue(scope, name);
@@ -296,6 +301,11 @@ public class SingleThreadEngine implements Engine {
     // Only allow enabling of manufacture, import, and export streams
     switch (name) {
       case "domestic", "import", "export" -> simulationState.markStreamAsEnabled(keyEffective, name);
+      case "virgin" -> {
+        simulationState.markStreamAsEnabled(keyEffective, "domestic");
+        simulationState.markStreamAsEnabled(keyEffective, "import");
+        simulationState.markStreamAsEnabled(keyEffective, "virgin");
+      }
       default -> {
         // Do nothing for other streams
       }
@@ -347,7 +357,7 @@ public class SingleThreadEngine implements Engine {
   @Override
   public EngineNumber getInitialCharge(String stream) {
     return switch (stream) {
-      case "sales" -> {
+      case "sales", "virgin" -> {
         try {
           yield getSalesWeightedInitialCharge();
         } catch (IllegalStateException e) {
@@ -391,7 +401,7 @@ public class SingleThreadEngine implements Engine {
     }
 
     switch (stream) {
-      case "sales" -> {
+      case "sales", "virgin" -> {
         simulationState.setInitialCharge(scope, "domestic", value);
         simulationState.setInitialCharge(scope, "import", value);
       }
@@ -435,7 +445,7 @@ public class SingleThreadEngine implements Engine {
         Optional<String> lastUnits = getLastSalesUnits(scope);
         yield lastUnits.isEmpty() || !lastUnits.get().startsWith("unit");
       }
-      case "domestic", "import" -> {
+      case "domestic", "import", "virgin" -> {
         Optional<String> lastUnits = getLastSalesUnits(scope);
         yield !lastUnits.isPresent() || !lastUnits.get().startsWith("unit");
       }

--- a/engine/src/main/java/org/kigalisim/engine/state/EngineConstants.java
+++ b/engine/src/main/java/org/kigalisim/engine/state/EngineConstants.java
@@ -56,6 +56,7 @@ public final class EngineConstants {
     units.put("import", "kg");
     units.put("export", "kg");
     units.put("sales", "kg");
+    units.put("virgin", "kg");
     units.put("energy", "kwh");
     units.put("recycle", "kg");
     units.put("recycleRecharge", "kg");

--- a/engine/src/main/java/org/kigalisim/engine/state/OverridingConverterStateGetter.java
+++ b/engine/src/main/java/org/kigalisim/engine/state/OverridingConverterStateGetter.java
@@ -61,7 +61,7 @@ public class OverridingConverterStateGetter implements StateGetter {
    */
   public void setTotal(String streamName, EngineNumber value) {
     switch (streamName) {
-      case "sales", "domestic", "import", "export" -> setVolume(value);
+      case "sales", "domestic", "import", "export", "virgin" -> setVolume(value);
       case "equipment", "priorEquipment" -> setPopulation(value);
       case "consumption" -> setConsumption(value);
       default -> throw new IllegalArgumentException("Unrecognized stream name: " + streamName);

--- a/engine/src/main/java/org/kigalisim/engine/state/SimulationState.java
+++ b/engine/src/main/java/org/kigalisim/engine/state/SimulationState.java
@@ -280,6 +280,7 @@ public class SimulationState {
     // Route based on stream type using a new-style switch
     switch (name) {
       case "sales" -> setStreamForSales(useKey, name, value);
+      case "virgin" -> setStreamForVirgin(useKey, name, value);
       case "domestic", "import" -> setStreamSalesSubstream(useKey, name, value, distribution);
       case "recycle" -> setStreamForRecycle(useKey, name, value);
       default -> {
@@ -376,6 +377,7 @@ public class SimulationState {
 
     return switch (name) {
       case "sales" -> getStreamSales(useKey, priorYear);
+      case "virgin" -> getStreamVirgin(useKey, priorYear);
       case "recycle" -> getStreamRecycle(useKey, priorYear);
       case "induction" -> getStreamInduction(useKey, priorYear);
       default -> getStreamDirect(useKey, name, priorYear);
@@ -414,6 +416,40 @@ public class SimulationState {
     BigDecimal recycleAmountValue = recycleAmount.getValue();
 
     BigDecimal newTotal = domesticAmountValue.add(importAmountValue).add(recycleAmountValue);
+
+    return new EngineNumber(newTotal, "kg");
+  }
+
+  /**
+   * Get the virgin stream value by summing domestic and import streams (excluding recycling).
+   * Uses current year.
+   *
+   * @param useKey The key containing application and substance
+   * @return The total virgin value in kg
+   */
+  private EngineNumber getStreamVirgin(UseKey useKey) {
+    return getStreamVirgin(useKey, false);
+  }
+
+  /**
+   * Get the virgin stream value by summing domestic and import streams (excluding recycling).
+   *
+   * @param useKey The key containing application and substance
+   * @param priorYear If true, returns prior year value if available, returns current year if no
+   *     prior year exists.
+   * @return The total virgin value in kg
+   */
+  private EngineNumber getStreamVirgin(UseKey useKey, boolean priorYear) {
+    EngineNumber domesticAmountRaw = getStream(useKey, "domestic", priorYear);
+    EngineNumber importAmountRaw = getStream(useKey, "import", priorYear);
+
+    EngineNumber domesticAmount = unitConverter.convert(domesticAmountRaw, "kg");
+    EngineNumber importAmount = unitConverter.convert(importAmountRaw, "kg");
+
+    BigDecimal domesticAmountValue = domesticAmount.getValue();
+    BigDecimal importAmountValue = importAmount.getValue();
+
+    BigDecimal newTotal = domesticAmountValue.add(importAmountValue);
 
     return new EngineNumber(newTotal, "kg");
   }
@@ -1536,6 +1572,36 @@ public class SimulationState {
   }
 
   /**
+   * Distribute a virgin stream value to domestic and import without recycling subtraction.
+   *
+   * <p>Unlike sales which subtracts recycling before distributing, virgin distributes
+   * the full amount to domestic and import. This is the key difference: virgin
+   * represents only domestic + import (excluding recycling).</p>
+   *
+   * @param useKey A key object representing the context for the virgin stream
+   * @param name The name associated with the stream being configured
+   * @param value The engine number input value to be distributed into domestic and import
+   */
+  private void setStreamForVirgin(UseKey useKey, String name, EngineNumber value) {
+    EngineNumber valueConverted = unitConverter.convert(value, "kg");
+    BigDecimal amountKg = valueConverted.getValue();
+
+    SalesStreamDistribution distribution = getDistribution(useKey);
+
+    BigDecimal domesticPercent = distribution.getPercentDomestic();
+    BigDecimal importPercent = distribution.getPercentImport();
+
+    BigDecimal newDomesticAmount = amountKg.multiply(domesticPercent);
+    BigDecimal newImportAmount = amountKg.multiply(importPercent);
+
+    EngineNumber domesticAmountToSet = new EngineNumber(newDomesticAmount, "kg");
+    EngineNumber importAmountToSet = new EngineNumber(newImportAmount, "kg");
+
+    setSimpleStream(useKey, "domestic", domesticAmountToSet);
+    setSimpleStream(useKey, "import", importAmountToSet);
+  }
+
+  /**
    * Sets the recycle stream by distributing the value proportionally between recycleRecharge and recycleEol.
    * Similar to sales distribution, this method uses the prior sizes of recycleRecharge and recycleEol
    * to determine the proportional distribution.
@@ -1713,7 +1779,7 @@ public class SimulationState {
    */
   private boolean getIsSettingVolumeByUnits(String name, EngineNumber value) {
     boolean isSalesComponent = switch (name) {
-      case "domestic", "import", "sales" -> true;
+      case "domestic", "import", "sales", "virgin" -> true;
       default -> false;
     };
     boolean isUnits = value.getUnits().startsWith("unit");

--- a/engine/src/main/java/org/kigalisim/engine/state/SimulationStateUpdateBuilder.java
+++ b/engine/src/main/java/org/kigalisim/engine/state/SimulationStateUpdateBuilder.java
@@ -114,7 +114,7 @@ public final class SimulationStateUpdateBuilder {
       return false;
     }
     return switch (streamName) {
-      case "sales", "domestic", "import", "export" -> true;
+      case "sales", "domestic", "import", "export", "virgin" -> true;
       default -> false;
     };
   }

--- a/engine/src/main/java/org/kigalisim/engine/state/StreamParameterization.java
+++ b/engine/src/main/java/org/kigalisim/engine/state/StreamParameterization.java
@@ -510,11 +510,12 @@ public class StreamParameterization {
     lastSpecifiedValue.put(streamName, value);
 
     // Set the flag if this is a sales-related stream
-    if ("sales".equals(streamName) || "import".equals(streamName) || "domestic".equals(streamName)
-        || "virgin".equals(streamName)) {
+    if (getIsSalesStream(streamName)) {
       salesIntentFreshlySet = true;
     }
   }
+
+
 
   /**
    * Get the last specified value for a stream.
@@ -662,7 +663,7 @@ public class StreamParameterization {
    */
   public void clearLastSpecifiedValue(String stream) {
     switch (stream) {
-      case "sales" -> {
+      case "sales", "virgin" -> {
         lastSpecifiedValue.remove("sales");
         lastSpecifiedValue.remove("import");
         lastSpecifiedValue.remove("domestic");
@@ -675,14 +676,20 @@ public class StreamParameterization {
         lastSpecifiedValue.remove("virgin");
         setSalesIntentFreshlySet(false);
       }
-      case "virgin" -> {
-        lastSpecifiedValue.remove("virgin");
-        lastSpecifiedValue.remove("sales");
-        lastSpecifiedValue.remove("import");
-        lastSpecifiedValue.remove("domestic");
-        setSalesIntentFreshlySet(false);
-      }
       default -> lastSpecifiedValue.remove(stream);
     }
+  }
+
+  /**
+   * Check if a stream name is a sales stream.
+   *
+   * @param streamName The stream name to check
+   * @return True if the stream is a sales stream, false otherwise
+   */
+  private boolean getIsSalesStream(String streamName) {
+    return switch (streamName) {
+      case "sales", "domestic", "import", "virgin" -> true;
+      default -> false;
+    };
   }
 }

--- a/engine/src/main/java/org/kigalisim/engine/state/StreamParameterization.java
+++ b/engine/src/main/java/org/kigalisim/engine/state/StreamParameterization.java
@@ -510,7 +510,8 @@ public class StreamParameterization {
     lastSpecifiedValue.put(streamName, value);
 
     // Set the flag if this is a sales-related stream
-    if ("sales".equals(streamName) || "import".equals(streamName) || "domestic".equals(streamName)) {
+    if ("sales".equals(streamName) || "import".equals(streamName) || "domestic".equals(streamName)
+        || "virgin".equals(streamName)) {
       salesIntentFreshlySet = true;
     }
   }
@@ -608,7 +609,7 @@ public class StreamParameterization {
    */
   private boolean getIsSalesStreamAllowed(String name) {
     return switch (name) {
-      case "domestic", "import", "export", "recycle", "recycleRecharge", "recycleEol" -> true;
+      case "domestic", "import", "export", "recycle", "recycleRecharge", "recycleEol", "virgin" -> true;
       default -> false;
     };
   }
@@ -665,11 +666,20 @@ public class StreamParameterization {
         lastSpecifiedValue.remove("sales");
         lastSpecifiedValue.remove("import");
         lastSpecifiedValue.remove("domestic");
+        lastSpecifiedValue.remove("virgin");
         setSalesIntentFreshlySet(false);
       }
       case "domestic", "import" -> {
         lastSpecifiedValue.remove(stream);
         lastSpecifiedValue.remove("sales");
+        lastSpecifiedValue.remove("virgin");
+        setSalesIntentFreshlySet(false);
+      }
+      case "virgin" -> {
+        lastSpecifiedValue.remove("virgin");
+        lastSpecifiedValue.remove("sales");
+        lastSpecifiedValue.remove("import");
+        lastSpecifiedValue.remove("domestic");
         setSalesIntentFreshlySet(false);
       }
       default -> lastSpecifiedValue.remove(stream);

--- a/engine/src/main/java/org/kigalisim/engine/support/ChangeExecutor.java
+++ b/engine/src/main/java/org/kigalisim/engine/support/ChangeExecutor.java
@@ -114,14 +114,10 @@ public class ChangeExecutor {
     }
 
     String stream = config.getStream();
-    if ("sales".equals(stream)) {
-      handleSalesChange(config);
-    } else if ("virgin".equals(stream)) {
-      handleSalesChange(config);
-    } else if (EngineSupportUtils.isSalesSubstream(stream) || "export".equals(stream)) {
-      handleComponentStream(config);
-    } else {
-      handleDerivedStream(config);
+    switch (stream) {
+      case "sales", "virgin" -> handleSalesChange(config);
+      case "domestic", "import", "export" -> handleComponentStream(config);
+      default -> handleDerivedStream(config);
     }
   }
 

--- a/engine/src/main/java/org/kigalisim/engine/support/ChangeExecutor.java
+++ b/engine/src/main/java/org/kigalisim/engine/support/ChangeExecutor.java
@@ -116,6 +116,8 @@ public class ChangeExecutor {
     String stream = config.getStream();
     if ("sales".equals(stream)) {
       handleSalesChange(config);
+    } else if ("virgin".equals(stream)) {
+      handleSalesChange(config);
     } else if (EngineSupportUtils.isSalesSubstream(stream) || "export".equals(stream)) {
       handleComponentStream(config);
     } else {
@@ -305,6 +307,7 @@ public class ChangeExecutor {
     BigDecimal recycleValue = recycleConverted.getValue();
     return switch (stream) {
       case "sales" -> recycleValue;
+      case "virgin" -> BigDecimal.ZERO;
       case "domestic" -> recycleValue.multiply(distribution.getPercentDomestic());
       case "import" -> recycleValue.multiply(distribution.getPercentImport());
       default -> BigDecimal.ZERO;

--- a/engine/src/main/java/org/kigalisim/engine/support/DisplaceExecutor.java
+++ b/engine/src/main/java/org/kigalisim/engine/support/DisplaceExecutor.java
@@ -377,7 +377,7 @@ public class DisplaceExecutor {
     simulationState.setLastSpecifiedValue(scope, stream, currentValue);
 
     // For "sales" or "virgin" stream, also update lastSpecified for component streams (domestic/import)
-    if ("sales".equals(stream) || "virgin".equals(stream)) {
+    if (EngineSupportUtils.isProductionMetastream(stream)) {
       EngineNumber domesticValue = engine.getStream("domestic");
       EngineNumber importValue = engine.getStream("import");
       simulationState.setLastSpecifiedValue(scope, "domestic", domesticValue);

--- a/engine/src/main/java/org/kigalisim/engine/support/DisplaceExecutor.java
+++ b/engine/src/main/java/org/kigalisim/engine/support/DisplaceExecutor.java
@@ -376,8 +376,8 @@ public class DisplaceExecutor {
     EngineNumber currentValue = engine.getStream(stream);
     simulationState.setLastSpecifiedValue(scope, stream, currentValue);
 
-    // For "sales" stream, also update lastSpecified for component streams (domestic/import)
-    if ("sales".equals(stream)) {
+    // For "sales" or "virgin" stream, also update lastSpecified for component streams (domestic/import)
+    if ("sales".equals(stream) || "virgin".equals(stream)) {
       EngineNumber domesticValue = engine.getStream("domestic");
       EngineNumber importValue = engine.getStream("import");
       simulationState.setLastSpecifiedValue(scope, "domestic", domesticValue);

--- a/engine/src/main/java/org/kigalisim/engine/support/EngineSupportUtils.java
+++ b/engine/src/main/java/org/kigalisim/engine/support/EngineSupportUtils.java
@@ -47,6 +47,7 @@ public final class EngineSupportUtils {
     STREAM_NAMES.add("import");
     STREAM_NAMES.add("domestic");
     STREAM_NAMES.add("sales");
+    STREAM_NAMES.add("virgin");
   }
 
   private EngineSupportUtils() {
@@ -85,7 +86,7 @@ public final class EngineSupportUtils {
    * @return true if the stream is domestic or import
    */
   public static boolean isSalesSubstream(String name) {
-    return "domestic".equals(name) || "import".equals(name);
+    return "domestic".equals(name) || "import".equals(name) || "virgin".equals(name);
   }
 
   /**
@@ -219,8 +220,7 @@ public final class EngineSupportUtils {
    */
   public static BigDecimal getDistributedRecharge(String streamName, EngineNumber totalRecharge,
       UseKey useKey, SimulationState simulationState) {
-    if ("sales".equals(streamName)) {
-      // Sales stream gets 100% - setStreamForSales will distribute it
+    if ("sales".equals(streamName) || "virgin".equals(streamName)) {
       return totalRecharge.getValue();
     }
 

--- a/engine/src/main/java/org/kigalisim/engine/support/EngineSupportUtils.java
+++ b/engine/src/main/java/org/kigalisim/engine/support/EngineSupportUtils.java
@@ -77,6 +77,20 @@ public final class EngineSupportUtils {
   }
 
   /**
+   * Check if a stream name represents a production metastream (sales or virgin).
+   *
+   * <p>Production metastreams are aggregate streams that represent production
+   * consumption within a country. Sales includes domestic, import, and recycling;
+   * virgin includes domestic and import only (excluding recycling).</p>
+   *
+   * @param name The stream name to check
+   * @return true if the stream is a production metastream (sales or virgin)
+   */
+  public static boolean isProductionMetastream(String name) {
+    return "sales".equals(name) || "virgin".equals(name);
+  }
+
+  /**
    * Check if a stream name represents a sales substream (domestic or import).
    *
    * <p>Sales substreams are the component streams that make up the overall sales stream,
@@ -220,7 +234,7 @@ public final class EngineSupportUtils {
    */
   public static BigDecimal getDistributedRecharge(String streamName, EngineNumber totalRecharge,
       UseKey useKey, SimulationState simulationState) {
-    if ("sales".equals(streamName) || "virgin".equals(streamName)) {
+    if (isProductionMetastream(streamName)) {
       return totalRecharge.getValue();
     }
 

--- a/engine/src/main/java/org/kigalisim/engine/support/LimitExecutor.java
+++ b/engine/src/main/java/org/kigalisim/engine/support/LimitExecutor.java
@@ -455,7 +455,7 @@ public class LimitExecutor {
     EngineNumber currentValue = engine.getStream(stream);
     simulationState.setLastSpecifiedValue(scope, stream, currentValue);
 
-    if ("sales".equals(stream)) {
+    if ("sales".equals(stream) || "virgin".equals(stream)) {
       updateComponentStreamsLastSpecified(simulationState, scope);
     }
   }

--- a/engine/src/main/java/org/kigalisim/engine/support/LimitExecutor.java
+++ b/engine/src/main/java/org/kigalisim/engine/support/LimitExecutor.java
@@ -455,7 +455,7 @@ public class LimitExecutor {
     EngineNumber currentValue = engine.getStream(stream);
     simulationState.setLastSpecifiedValue(scope, stream, currentValue);
 
-    if ("sales".equals(stream) || "virgin".equals(stream)) {
+    if (EngineSupportUtils.isProductionMetastream(stream)) {
       updateComponentStreamsLastSpecified(simulationState, scope);
     }
   }

--- a/engine/src/main/java/org/kigalisim/engine/support/SetExecutor.java
+++ b/engine/src/main/java/org/kigalisim/engine/support/SetExecutor.java
@@ -94,4 +94,57 @@ public class SetExecutor {
       engine.executeStreamUpdate(update);
     }
   }
+
+  /**
+   * Handle virgin stream setting by distributing to component streams without recycling subtraction.
+   *
+   * <p>Unlike sales which subtracts recycling before distributing, virgin distributes
+   * the full amount to domestic and import. This is the key difference: virgin
+   * represents only domestic + import (excluding recycling).</p>
+   *
+   * @param useKey The use key for the operation scope
+   * @param stream The stream identifier (should be "virgin")
+   * @param value The value to set
+   * @param yearMatcher Optional year matcher for conditional setting
+   */
+  public void handleVirginSet(UseKey useKey, String stream, EngineNumber value,
+        Optional<YearMatcher> yearMatcher) {
+    boolean hasYearMatch = yearMatcher.isPresent();
+    boolean inRange = hasYearMatch && !EngineSupportUtils.getIsInRange(
+        yearMatcher.get(),
+        engine.getYear()
+    );
+    if (inRange) {
+      return;
+    }
+
+    SimulationState simulationState = engine.getStreamKeeper();
+    simulationState.setLastSpecifiedValue(useKey, "virgin", value);
+    SalesStreamDistribution distribution = simulationState.getDistribution(useKey);
+
+    BigDecimal domesticAmount = value.getValue().multiply(distribution.getPercentDomestic());
+    BigDecimal importAmount = value.getValue().multiply(distribution.getPercentImport());
+
+    if (distribution.getPercentDomestic().compareTo(BigDecimal.ZERO) > 0) {
+      EngineNumber domesticValue = new EngineNumber(domesticAmount, value.getUnits());
+      StreamUpdate update = new StreamUpdateBuilder()
+          .setName("domestic")
+          .setValue(domesticValue)
+          .setYearMatcher(yearMatcher)
+          .setSubtractRecycling(false)
+          .build();
+      engine.executeStreamUpdate(update);
+    }
+
+    if (distribution.getPercentImport().compareTo(BigDecimal.ZERO) > 0) {
+      EngineNumber importValue = new EngineNumber(importAmount, value.getUnits());
+      StreamUpdate update = new StreamUpdateBuilder()
+          .setName("import")
+          .setValue(importValue)
+          .setYearMatcher(yearMatcher)
+          .setSubtractRecycling(false)
+          .build();
+      engine.executeStreamUpdate(update);
+    }
+  }
 }

--- a/engine/src/main/java/org/kigalisim/engine/support/StreamUpdateExecutor.java
+++ b/engine/src/main/java/org/kigalisim/engine/support/StreamUpdateExecutor.java
@@ -148,6 +148,11 @@ public class StreamUpdateExecutor {
       return;
     }
 
+    // Virgin is a computed composite (domestic + import), skip binary complement logic
+    if ("virgin".equals(streamName)) {
+      return;
+    }
+
     SimulationState simulationState = engine.getStreamKeeper();
 
     // If there is a single sales stream active, setting the substream is the same as setting sales

--- a/engine/src/test/java/org/kigalisim/engine/state/SimulationStateTest.java
+++ b/engine/src/test/java/org/kigalisim/engine/state/SimulationStateTest.java
@@ -232,6 +232,50 @@ public class SimulationStateTest {
   }
 
   /**
+   * Test that virgin stream returns sum of manufacture and import (excluding recycle).
+   */
+  @Test
+  public void testVirginStreamReturnsSumOfManufactureAndImportWithoutRecycle() {
+    SimulationState keeper = createMockKeeper();
+    Scope testScope = createTestScope();
+    keeper.ensureSubstance(testScope);
+
+    // Enable the streams first
+    keeper.markStreamAsEnabled(testScope, "domestic");
+    keeper.markStreamAsEnabled(testScope, "import");
+
+    // Set streams using SimulationStateUpdate architecture
+    SimulationStateUpdate domesticStream = new SimulationStateUpdateBuilder()
+        .setUseKey(testScope)
+        .setName("domestic")
+        .setValue(new EngineNumber(new BigDecimal("50"), "kg"))
+        .setSubtractRecycling(false)
+        .build();
+    keeper.update(domesticStream);
+
+    SimulationStateUpdate importStream = new SimulationStateUpdateBuilder()
+        .setUseKey(testScope)
+        .setName("import")
+        .setValue(new EngineNumber(new BigDecimal("30"), "kg"))
+        .setSubtractRecycling(false)
+        .build();
+    keeper.update(importStream);
+
+    SimulationStateUpdate recycleStream = new SimulationStateUpdateBuilder()
+        .setUseKey(testScope)
+        .setName("recycle")
+        .setValue(new EngineNumber(new BigDecimal("10"), "kg"))
+        .setSubtractRecycling(false)
+        .build();
+    keeper.update(recycleStream);
+
+    EngineNumber virgin = keeper.getStream(testScope, "virgin");
+    assertEquals(0, virgin.getValue().compareTo(new BigDecimal("80")),
+                 "Virgin should be sum of manufacture and import only (excluding recycle)");
+    assertEquals("kg", virgin.getUnits(), "Virgin should have kg units");
+  }
+
+  /**
    * Test that GHG intensity getter and setter delegate to parameterization.
    */
   @Test

--- a/engine/src/test/java/org/kigalisim/engine/state/StreamParameterizationTest.java
+++ b/engine/src/test/java/org/kigalisim/engine/state/StreamParameterizationTest.java
@@ -289,6 +289,28 @@ public class StreamParameterizationTest {
   }
 
   /**
+   * Test setting and getting last specified value for virgin stream.
+   */
+  @Test
+  public void testSetAndGetLastSpecifiedValueForVirgin() {
+    StreamParameterization parameterization = new StreamParameterization();
+
+    // Test setting a value for virgin stream
+    EngineNumber testValue = new EngineNumber(new BigDecimal("500"), "units");
+    parameterization.setLastSpecifiedValue("virgin", testValue);
+
+    // Test getting the value back
+    EngineNumber retrieved = parameterization.getLastSpecifiedValue("virgin");
+    assertNotNull(retrieved, "Retrieved value should not be null");
+    assertEquals(new BigDecimal("500"), retrieved.getValue(), "Value should match");
+    assertEquals("units", retrieved.getUnits(), "Units should match");
+
+    // Test getting a non-existent value
+    EngineNumber nonExistent = parameterization.getLastSpecifiedValue("sales");
+    assertEquals(null, nonExistent, "Non-existent value should be null");
+  }
+
+  /**
    * Test tracking of has last specified.
    */
   @Test

--- a/engine/src/test/java/org/kigalisim/engine/support/EngineSupportUtilsTest.java
+++ b/engine/src/test/java/org/kigalisim/engine/support/EngineSupportUtilsTest.java
@@ -89,6 +89,25 @@ class EngineSupportUtilsTest {
   }
 
   @Test
+  void testIsProductionMetastreamSales() {
+    assertTrue(EngineSupportUtils.isProductionMetastream("sales"));
+  }
+
+  @Test
+  void testIsProductionMetastreamVirgin() {
+    assertTrue(EngineSupportUtils.isProductionMetastream("virgin"));
+  }
+
+  @Test
+  void testIsProductionMetastreamFalseForOtherStreams() {
+    assertFalse(EngineSupportUtils.isProductionMetastream("domestic"));
+    assertFalse(EngineSupportUtils.isProductionMetastream("import"));
+    assertFalse(EngineSupportUtils.isProductionMetastream("export"));
+    assertFalse(EngineSupportUtils.isProductionMetastream("equipment"));
+    assertFalse(EngineSupportUtils.isProductionMetastream(null));
+  }
+
+  @Test
   void testIsSalesSubstreamFalseForOtherStreams() {
     // Act & Assert
     assertFalse(EngineSupportUtils.isSalesSubstream("sales"));

--- a/engine/src/test/java/org/kigalisim/engine/support/EngineSupportUtilsTest.java
+++ b/engine/src/test/java/org/kigalisim/engine/support/EngineSupportUtilsTest.java
@@ -82,6 +82,13 @@ class EngineSupportUtilsTest {
   }
 
   @Test
+  void testIsVirginSubstream() {
+    // Act & Assert - virgin is a sales-related substream but handled differently
+    // virgin represents domestic + import without recycling
+    assertTrue(EngineSupportUtils.isSalesSubstream("virgin"));
+  }
+
+  @Test
   void testIsSalesSubstreamFalseForOtherStreams() {
     // Act & Assert
     assertFalse(EngineSupportUtils.isSalesSubstream("sales"));

--- a/engine/src/test/java/org/kigalisim/engine/support/ReplaceExecutorTest.java
+++ b/engine/src/test/java/org/kigalisim/engine/support/ReplaceExecutorTest.java
@@ -139,6 +139,26 @@ class ReplaceExecutorTest {
   }
 
   @Test
+  void testExecuteVirginStreamUpdatesLastSpecifiedForBothSubstances() {
+    // Arrange
+    setStreamValue("virgin", new BigDecimal("100"), "kg");
+    YearMatcher matcher = new YearMatcher(2020, 2025);
+    EngineNumber amount = new EngineNumber(new BigDecimal("50"), "kg");
+
+    // Act
+    replaceExecutor.execute(amount, "virgin", "R-600a", matcher);
+
+    // Assert - verify lastSpecifiedValue was set for both substances
+    UseKey sourceKey = new SimpleUseKey("TestApp", "HFC-134a");
+    EngineNumber sourceLastSpec = engine.getStreamKeeper().getLastSpecifiedValue(sourceKey, "virgin");
+    assertTrue(sourceLastSpec != null, "Source substance should have lastSpecifiedValue set for virgin");
+
+    UseKey destKey = new SimpleUseKey("TestApp", "R-600a");
+    EngineNumber destLastSpec = engine.getStreamKeeper().getLastSpecifiedValue(destKey, "virgin");
+    assertTrue(destLastSpec != null, "Destination substance should have lastSpecifiedValue set for virgin");
+  }
+
+  @Test
   void testExecuteNonSalesStreamDoesNotUpdateLastSpecified() {
     // Arrange
     setStreamValue("equipment", new BigDecimal("100"), "units");

--- a/engine/src/test/java/org/kigalisim/engine/support/StreamUpdateExecutorTest.java
+++ b/engine/src/test/java/org/kigalisim/engine/support/StreamUpdateExecutorTest.java
@@ -370,6 +370,52 @@ class StreamUpdateExecutorTest {
   }
 
   /**
+   * Tests that virgin stream updates sales intent similar to domestic/import streams.
+   */
+  @Test
+  void testUpdateVirginCarryOverReplacesExistingIntent() {
+    // Arrange
+    final EngineNumber domestic = new EngineNumber(new BigDecimal("100"), "units");
+    final EngineNumber importValue = new EngineNumber(new BigDecimal("50"), "units");
+    final EngineNumber virginValue = new EngineNumber(new BigDecimal("75"), "units");
+
+    // Enable streams before setting values
+    engine.enable("domestic", Optional.empty());
+    engine.enable("import", Optional.empty());
+    engine.enable("virgin", Optional.empty());
+
+    // Act - use execute() to set streams
+    StreamUpdate domesticUpdate = new StreamUpdateBuilder()
+        .setName("domestic")
+        .setValue(domestic)
+        .setPropagateChanges(true)
+        .build();
+    executor.execute(domesticUpdate);
+
+    StreamUpdate importUpdate = new StreamUpdateBuilder()
+        .setName("import")
+        .setValue(importValue)
+        .setPropagateChanges(true)
+        .build();
+    executor.execute(importUpdate);
+
+    // Act - set virgin stream
+    StreamUpdate virginUpdate = new StreamUpdateBuilder()
+        .setName("virgin")
+        .setValue(virginValue)
+        .setPropagateChanges(true)
+        .build();
+    executor.execute(virginUpdate);
+
+    // Assert
+    EngineNumber virginIntent = engine.getStreamKeeper().getLastSpecifiedValue(useKey, "virgin");
+    assertNotNull(virginIntent, "Virgin intent should be set when virgin stream has unit value");
+    assertEquals(0, new BigDecimal("75").compareTo(virginIntent.getValue()),
+        "Virgin intent should match virgin value");
+    assertEquals("units", virginIntent.getUnits());
+  }
+
+  /**
    * Tests implicit recharge calculation and application for sales streams with units.
    */
   @Test

--- a/engine/src/test/java/org/kigalisim/validate/BasicLiveTests.java
+++ b/engine/src/test/java/org/kigalisim/validate/BasicLiveTests.java
@@ -1230,8 +1230,8 @@ public class BasicLiveTests {
     EngineResult result = LiveTestsUtil.getResult(resultsList.stream(), 2025, "Test", "HFC-134a");
     assertNotNull(result, "Should have result for Test/HFC-134a in year 2025");
 
-    assertEquals(2667.0, result.getPopulation().getValue().doubleValue(), 0.0001,
-        "Equipment should be 2667 units");
+    assertEquals(242667.0, result.getPopulation().getValue().doubleValue(), 0.0001,
+        "Equipment should be 242667 units");
     assertEquals("units", result.getPopulation().getUnits(),
         "Equipment units should be units");
   }

--- a/engine/src/test/java/org/kigalisim/validate/BasicLiveTests.java
+++ b/engine/src/test/java/org/kigalisim/validate/BasicLiveTests.java
@@ -1188,4 +1188,52 @@ public class BasicLiveTests {
         "Domestic units should be kg");
   }
 
+  /**
+   * Test set_virgin.qta produces expected values for virgin stream.
+   * Virgin should be sum of domestic and import (excluding recycle).
+   */
+  @Test
+  public void testSetVirgin() throws IOException {
+    String qtaPath = "../examples/set_virgin.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    String scenarioName = "BAU";
+    Stream<EngineResult> results = KigaliSimFacade.runScenario(program, scenarioName, progress -> {});
+
+    List<EngineResult> resultsList = results.collect(Collectors.toList());
+    EngineResult result = LiveTestsUtil.getResult(resultsList.stream(), 1, "Test", "SubA");
+    assertNotNull(result, "Should have result for Test/SubA in year 1");
+
+    double virginTotal = result.getDomestic().getValue().doubleValue()
+                       + result.getImport().getValue().doubleValue();
+    assertEquals(1000.0, virginTotal, 0.0001,
+        "Virgin (domestic + import) should be 1000 kg (1 mt)");
+    assertEquals("kg", result.getDomestic().getUnits(),
+        "Domestic units should be kg");
+  }
+
+  /**
+   * Test basic_virgin.qta produces expected values for virgin stream.
+   * Virgin should be sum of domestic and import (excluding recycle).
+   */
+  @Test
+  public void testBasicVirgin() throws IOException {
+    String qtaPath = "../examples/basic_virgin.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    String scenarioName = "business as usual";
+    Stream<EngineResult> results = KigaliSimFacade.runScenario(program, scenarioName, progress -> {});
+
+    List<EngineResult> resultsList = results.collect(Collectors.toList());
+    EngineResult result = LiveTestsUtil.getResult(resultsList.stream(), 2025, "Test", "HFC-134a");
+    assertNotNull(result, "Should have result for Test/HFC-134a in year 2025");
+
+    assertEquals(2667.0, result.getPopulation().getValue().doubleValue(), 0.0001,
+        "Equipment should be 2667 units");
+    assertEquals("units", result.getPopulation().getUnits(),
+        "Equipment units should be units");
+  }
+
 }

--- a/engine/src/test/java/org/kigalisim/validate/CapLiveTests.java
+++ b/engine/src/test/java/org/kigalisim/validate/CapLiveTests.java
@@ -922,10 +922,7 @@ public class CapLiveTests {
     List<EngineResult> limitRecycleResultsList = limitRecycleResults.collect(Collectors.toList());
     EngineResult limitRecycleYear2 = LiveTestsUtil.getResult(limitRecycleResultsList.stream(), 2, "test", "test");
     assertNotNull(limitRecycleYear2, "Should have limit recycling result for test/test in year 2");
-    double limitRecycleVirginYear2 = limitRecycleYear2.getDomestic().getValue().doubleValue()
-        + limitRecycleYear2.getImport().getValue().doubleValue();
     EngineResult bauYear1 = LiveTestsUtil.getResult(bauResultsList.stream(), 1, "test", "test");
-    EngineResult limitRecycleYear1 = LiveTestsUtil.getResult(limitRecycleResultsList.stream(), 1, "test", "test");
     assertTrue(bauYear1.getRecycle().getValue().doubleValue() > 0,
         "BAU year 1 recycle should be > 0 (was " + bauYear1.getRecycle().getValue() + ")");
     assertTrue(bauYear1.getRecycleConsumption().getValue().doubleValue() > 0,
@@ -934,6 +931,7 @@ public class CapLiveTests {
         "BAU year 2 recycle should be > 0 (was " + bauYear2.getRecycle().getValue() + ")");
     assertTrue(bauYear2.getRecycleConsumption().getValue().doubleValue() > 0,
         "BAU year 2 recycleConsumption should be > 0 (was " + bauYear2.getRecycleConsumption().getValue() + ")");
+    EngineResult limitRecycleYear1 = LiveTestsUtil.getResult(limitRecycleResultsList.stream(), 1, "test", "test");
     assertTrue(limitRecycleYear1.getRecycle().getValue().doubleValue() > 0,
         "Limit recycle year 1 recycle should be > 0 (was " + limitRecycleYear1.getRecycle().getValue() + ")");
     assertTrue(limitRecycleYear1.getRecycleConsumption().getValue().doubleValue() > 0,
@@ -943,6 +941,8 @@ public class CapLiveTests {
     assertTrue(limitRecycleYear2.getRecycleConsumption().getValue().doubleValue() > 0,
         "Limit recycle year 2 recycleConsumption should be > 0 (was " + limitRecycleYear2.getRecycleConsumption().getValue() + ")");
 
+    double limitRecycleVirginYear2 = limitRecycleYear2.getDomestic().getValue().doubleValue()
+        + limitRecycleYear2.getImport().getValue().doubleValue();
     assertTrue(limitRecycleVirginYear2 > bauVirginYear2,
         "Virgin should be higher when recycling is limited (was "
         + limitRecycleVirginYear2 + " vs BAU " + bauVirginYear2 + ")");

--- a/engine/src/test/java/org/kigalisim/validate/CapLiveTests.java
+++ b/engine/src/test/java/org/kigalisim/validate/CapLiveTests.java
@@ -880,4 +880,71 @@ public class CapLiveTests {
           + " (both mean prior year in cap context)");
     }
   }
+
+  /**
+   * Test cap_recycle_with_virgin.qta produces expected relative behavior.
+   * With limited recycling, virgin should be higher than BAU.
+   * With virgin capped, both virgin and equipment should be lower than BAU.
+   */
+  @Test
+  public void testCapRecycleWithVirgin() throws IOException {
+    String qtaPath = "../examples/cap_recycle_with_virgin.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    String limitVirginScenario = "limit virgin";
+    Stream<EngineResult> limitVirginResults = KigaliSimFacade.runScenario(program, limitVirginScenario, progress -> {});
+    List<EngineResult> limitVirginResultsList = limitVirginResults.collect(Collectors.toList());
+    EngineResult limitVirginYear2 = LiveTestsUtil.getResult(limitVirginResultsList.stream(), 2, "test", "test");
+    assertNotNull(limitVirginYear2, "Should have limit virgin result for test/test in year 2");
+    double limitVirginVirginYear2 = limitVirginYear2.getDomestic().getValue().doubleValue()
+        + limitVirginYear2.getImport().getValue().doubleValue();
+
+    String bauScenario = "business as usual";
+    Stream<EngineResult> bauResults = KigaliSimFacade.runScenario(program, bauScenario, progress -> {});
+    List<EngineResult> bauResultsList = bauResults.collect(Collectors.toList());
+    EngineResult bauYear2 = LiveTestsUtil.getResult(bauResultsList.stream(), 2, "test", "test");
+    assertNotNull(bauYear2, "Should have BAU result for test/test in year 2");
+    double bauVirginYear2 = bauYear2.getDomestic().getValue().doubleValue()
+        + bauYear2.getImport().getValue().doubleValue();
+
+    assertTrue(limitVirginVirginYear2 < bauVirginYear2,
+        "Virgin should be lower when capped (was "
+        + limitVirginVirginYear2 + " vs BAU " + bauVirginYear2 + ")");
+    assertTrue(limitVirginYear2.getPopulation().getValue().doubleValue()
+        < bauYear2.getPopulation().getValue().doubleValue(),
+        "Equipment should be lower when virgin is capped (was "
+        + limitVirginYear2.getPopulation().getValue().doubleValue()
+        + " vs BAU " + bauYear2.getPopulation().getValue().doubleValue() + ")");
+
+    String limitRecycleScenario = "limit recycling";
+    Stream<EngineResult> limitRecycleResults = KigaliSimFacade.runScenario(program, limitRecycleScenario, progress -> {});
+    List<EngineResult> limitRecycleResultsList = limitRecycleResults.collect(Collectors.toList());
+    EngineResult limitRecycleYear2 = LiveTestsUtil.getResult(limitRecycleResultsList.stream(), 2, "test", "test");
+    assertNotNull(limitRecycleYear2, "Should have limit recycling result for test/test in year 2");
+    double limitRecycleVirginYear2 = limitRecycleYear2.getDomestic().getValue().doubleValue()
+        + limitRecycleYear2.getImport().getValue().doubleValue();
+    EngineResult bauYear1 = LiveTestsUtil.getResult(bauResultsList.stream(), 1, "test", "test");
+    EngineResult limitRecycleYear1 = LiveTestsUtil.getResult(limitRecycleResultsList.stream(), 1, "test", "test");
+    assertTrue(bauYear1.getRecycle().getValue().doubleValue() > 0,
+        "BAU year 1 recycle should be > 0 (was " + bauYear1.getRecycle().getValue() + ")");
+    assertTrue(bauYear1.getRecycleConsumption().getValue().doubleValue() > 0,
+        "BAU year 1 recycleConsumption should be > 0 (was " + bauYear1.getRecycleConsumption().getValue() + ")");
+    assertTrue(bauYear2.getRecycle().getValue().doubleValue() > 0,
+        "BAU year 2 recycle should be > 0 (was " + bauYear2.getRecycle().getValue() + ")");
+    assertTrue(bauYear2.getRecycleConsumption().getValue().doubleValue() > 0,
+        "BAU year 2 recycleConsumption should be > 0 (was " + bauYear2.getRecycleConsumption().getValue() + ")");
+    assertTrue(limitRecycleYear1.getRecycle().getValue().doubleValue() > 0,
+        "Limit recycle year 1 recycle should be > 0 (was " + limitRecycleYear1.getRecycle().getValue() + ")");
+    assertTrue(limitRecycleYear1.getRecycleConsumption().getValue().doubleValue() > 0,
+        "Limit recycle year 1 recycleConsumption should be > 0 (was " + limitRecycleYear1.getRecycleConsumption().getValue() + ")");
+    assertTrue(limitRecycleYear2.getRecycle().getValue().doubleValue() > 0,
+        "Limit recycle year 2 recycle should be > 0 (was " + limitRecycleYear2.getRecycle().getValue() + ")");
+    assertTrue(limitRecycleYear2.getRecycleConsumption().getValue().doubleValue() > 0,
+        "Limit recycle year 2 recycleConsumption should be > 0 (was " + limitRecycleYear2.getRecycleConsumption().getValue() + ")");
+
+    assertTrue(limitRecycleVirginYear2 > bauVirginYear2,
+        "Virgin should be higher when recycling is limited (was "
+        + limitRecycleVirginYear2 + " vs BAU " + bauVirginYear2 + ")");
+  }
 }

--- a/engine/src/test/java/org/kigalisim/validate/CapLiveTests.java
+++ b/engine/src/test/java/org/kigalisim/validate/CapLiveTests.java
@@ -825,6 +825,31 @@ public class CapLiveTests {
   }
 
   /**
+   * Test cap_virgin.qta produces expected values.
+   * This tests capping virgin (domestic + import) to a specific weight in kg.
+   */
+  @Test
+  public void testCapVirgin() throws IOException {
+    String qtaPath = "../examples/cap_virgin.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    String scenarioName = "result";
+    Stream<EngineResult> results = KigaliSimFacade.runScenario(program, scenarioName, progress -> {});
+
+    List<EngineResult> resultsList = results.collect(Collectors.toList());
+    EngineResult result = LiveTestsUtil.getResult(resultsList.stream(), 1, "test", "test");
+    assertNotNull(result, "Should have result for test/test in year 1");
+
+    double virginTotal = result.getDomestic().getValue().doubleValue()
+                       + result.getImport().getValue().doubleValue();
+    assertEquals(100.0, virginTotal, 0.0001,
+        "Virgin (domestic + import) should be capped at 100 kg");
+    assertEquals("kg", result.getDomestic().getUnits(),
+        "Domestic units should be kg");
+  }
+
+  /**
    * Test cap with % prior year behaves identically to cap with %.
    * This validates that % and % prior year in cap context both mean prior year values.
    */

--- a/engine/src/test/java/org/kigalisim/validate/ChangeLiveTests.java
+++ b/engine/src/test/java/org/kigalisim/validate/ChangeLiveTests.java
@@ -801,6 +801,32 @@ public class ChangeLiveTests {
   }
 
   /**
+   * Test change_virgin.qta produces expected values.
+   * This tests changing virgin (domestic + import) by +10% each year.
+   */
+  @Test
+  public void testChangeVirgin() throws IOException {
+    String qtaPath = "../examples/change_virgin.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    String scenarioName = "business as usual";
+    Stream<EngineResult> results = KigaliSimFacade.runScenario(program, scenarioName, progress -> {});
+
+    List<EngineResult> resultsList = results.collect(Collectors.toList());
+
+    EngineResult result = LiveTestsUtil.getResult(resultsList.stream(), 2, "test", "test");
+    assertNotNull(result, "Should have result for test/test in year 2");
+
+    double virginTotal = result.getDomestic().getValue().doubleValue()
+                       + result.getImport().getValue().doubleValue();
+    assertEquals(165000.0, virginTotal, 0.0001,
+        "Virgin (domestic + import) should be 165000 kg in year 2 (150 mt + 10%)");
+    assertEquals("kg", result.getDomestic().getUnits(),
+        "Domestic units should be kg");
+  }
+
+  /**
    * Test that change operations prevent negative stream values.
    * When a change would result in a negative value, the stream should be clamped to zero.
    * This test documents the bug and should initially FAIL.

--- a/engine/src/test/java/org/kigalisim/validate/FloorLiveTests.java
+++ b/engine/src/test/java/org/kigalisim/validate/FloorLiveTests.java
@@ -126,6 +126,32 @@ public class FloorLiveTests {
   }
 
   /**
+   * Test floor_virgin.qta produces expected values.
+   * This tests flooring virgin (domestic + import) to a specific weight in kg.
+   */
+  @Test
+  public void testFloorVirgin() throws IOException {
+    String qtaPath = "../examples/floor_virgin.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    String scenarioName = "result";
+    Stream<EngineResult> results = KigaliSimFacade.runScenario(program, scenarioName, progress -> {});
+
+    List<EngineResult> resultsList = results.collect(Collectors.toList());
+
+    EngineResult result = LiveTestsUtil.getResult(resultsList.stream(), 1, "test", "test");
+    assertNotNull(result, "Should have result for test/test in year 1");
+
+    double virginTotal = result.getDomestic().getValue().doubleValue()
+                       + result.getImport().getValue().doubleValue();
+    assertEquals(20.0, virginTotal, 0.0001,
+        "Virgin (domestic + import) should be floored to 20 kg");
+    assertEquals("kg", result.getDomestic().getUnits(),
+        "Domestic units should be kg");
+  }
+
+  /**
    * Test floor on equipment stream when no action is required.
    * This verifies that when equipment is already above the floor, no changes occur.
    */

--- a/engine/src/test/java/org/kigalisim/validate/ReplaceLiveTests.java
+++ b/engine/src/test/java/org/kigalisim/validate/ReplaceLiveTests.java
@@ -321,7 +321,7 @@ public class ReplaceLiveTests {
     assertNotNull(resultA, "Should have result for test/a in year 1");
 
     assertEquals(500.0, resultA.getConsumption().getValue().doubleValue(), 0.0001,
-        "Consumption for substance a should be 500 tCO2e (50 mt remaining x 10 tCO2e/mt)");
+        "Consumption for substance a should be 500 tCO2e (50 mt remaining × 10 tCO2e/mt)");
     assertEquals("tCO2e", resultA.getConsumption().getUnits(),
         "Consumption units should be tCO2e");
 
@@ -329,7 +329,7 @@ public class ReplaceLiveTests {
     assertNotNull(resultRecycling, "Should have result for test/recycling in year 1");
 
     assertEquals(750.0, resultRecycling.getConsumption().getValue().doubleValue(), 0.0001,
-        "Consumption for substance recycling should be 750 tCO2e (150 mt total x 5 tCO2e/mt)");
+        "Consumption for substance recycling should be 750 tCO2e (150 mt total × 5 tCO2e/mt)");
     assertEquals("tCO2e", resultRecycling.getConsumption().getUnits(),
         "Consumption units should be tCO2e");
   }

--- a/engine/src/test/java/org/kigalisim/validate/ReplaceLiveTests.java
+++ b/engine/src/test/java/org/kigalisim/validate/ReplaceLiveTests.java
@@ -270,6 +270,71 @@ public class ReplaceLiveTests {
   }
 
   /**
+   * Test replace_virgin.qta produces expected values.
+   * This tests replacing a percentage of virgin from one substance to another.
+   */
+  @Test
+  public void testReplaceVirgin() throws IOException {
+    String qtaPath = "../examples/replace_virgin.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    String scenarioName = "result";
+    Stream<EngineResult> results = KigaliSimFacade.runScenario(program, scenarioName, progress -> {});
+
+    List<EngineResult> resultsList = results.collect(Collectors.toList());
+
+    EngineResult resultA = LiveTestsUtil.getResult(resultsList.stream(), 1, "test", "a");
+    assertNotNull(resultA, "Should have result for test/a in year 1");
+
+    assertEquals(500.0, resultA.getConsumption().getValue().doubleValue(), 0.0001,
+        "Consumption for substance a should be 500 tCO2e (50 mt remaining × 10 tCO2e/mt)");
+    assertEquals("tCO2e", resultA.getConsumption().getUnits(),
+        "Consumption units should be tCO2e");
+
+    EngineResult resultB = LiveTestsUtil.getResult(resultsList.stream(), 1, "test", "b");
+    assertNotNull(resultB, "Should have result for test/b in year 1");
+
+    assertEquals(750.0, resultB.getConsumption().getValue().doubleValue(), 0.0001,
+        "Consumption for substance b should be 750 tCO2e (150 mt total × 5 tCO2e/mt)");
+    assertEquals("tCO2e", resultB.getConsumption().getUnits(),
+        "Consumption units should be tCO2e");
+  }
+
+  /**
+   * Test replace_virgin_recycling.qta produces expected values.
+   * This tests replacing a percentage of virgin from one substance to another
+   * where the target substance has recycling enabled.
+   */
+  @Test
+  public void testReplaceVirginRecycling() throws IOException {
+    String qtaPath = "../examples/replace_virgin_recycling.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    String scenarioName = "result";
+    Stream<EngineResult> results = KigaliSimFacade.runScenario(program, scenarioName, progress -> {});
+
+    List<EngineResult> resultsList = results.collect(Collectors.toList());
+
+    EngineResult resultA = LiveTestsUtil.getResult(resultsList.stream(), 1, "test", "a");
+    assertNotNull(resultA, "Should have result for test/a in year 1");
+
+    assertEquals(500.0, resultA.getConsumption().getValue().doubleValue(), 0.0001,
+        "Consumption for substance a should be 500 tCO2e (50 mt remaining x 10 tCO2e/mt)");
+    assertEquals("tCO2e", resultA.getConsumption().getUnits(),
+        "Consumption units should be tCO2e");
+
+    EngineResult resultRecycling = LiveTestsUtil.getResult(resultsList.stream(), 1, "test", "recycling");
+    assertNotNull(resultRecycling, "Should have result for test/recycling in year 1");
+
+    assertEquals(750.0, resultRecycling.getConsumption().getValue().doubleValue(), 0.0001,
+        "Consumption for substance recycling should be 750 tCO2e (150 mt total x 5 tCO2e/mt)");
+    assertEquals("tCO2e", resultRecycling.getConsumption().getUnits(),
+        "Consumption units should be tCO2e");
+  }
+
+  /**
    * Test that 100% replacement should produce the same total equipment population
    * as cap displacement in year 5. This tests if priorEquipment replacement
    * properly reflects into equipment totals.

--- a/examples/basic_virgin.qta
+++ b/examples/basic_virgin.qta
@@ -1,0 +1,27 @@
+start default
+
+  define application "Test"
+
+    uses substance "HFC-134a"
+      enable domestic
+      enable import
+      initial charge with 0.6 kg / unit for domestic
+      initial charge with 0.6 kg / unit for import
+      equals 1430 tCO2e / kg
+      set priorEquipment to 240000 units during year beginning
+      set domestic to 2000 units during year 2025
+      set import to 667 units during year 2025
+      set virgin to 2667 units during year 2025
+    end substance
+
+  end application
+
+end default
+
+
+start simulations
+
+  simulate "business as usual"
+  from years 2025 to 2035
+
+end simulations

--- a/examples/cap_recycle_with_virgin.qta
+++ b/examples/cap_recycle_with_virgin.qta
@@ -1,0 +1,46 @@
+start default
+  define application "test"
+    uses substance "test"
+      enable domestic
+      enable import
+      initial charge with 1 kg / unit for domestic
+      initial charge with 1 kg / unit for import
+      equals 5 tCO2e / mt
+      set priorEquipment to 100 units during year 1
+      retire 10 % each year
+      set domestic to 50 kg during year 1
+      set import to 50 kg during year 1
+      set sales to 100 units during year 1
+    end substance
+  end application
+end default
+
+start policy "full_recycle"
+  modify application "test"
+    modify substance "test"
+      recover 100 % with 100 % reuse with 0 % induction at eol during years 1 to 2
+    end substance
+  end application
+end policy
+
+start policy "limited_recycle"
+  modify application "test"
+    modify substance "test"
+      recover 50 % with 100 % reuse with 0 % induction at eol during years 1 to 2
+    end substance
+  end application
+end policy
+
+start policy "virgin_cap"
+  modify application "test"
+    modify substance "test"
+      cap virgin to 50 kg during year 2
+    end substance
+  end application
+end policy
+
+start simulations
+  simulate "business as usual" using "full_recycle" from years 1 to 2
+  simulate "limit recycling" using "limited_recycle" from years 1 to 2
+  simulate "limit virgin" using "full_recycle" then "virgin_cap" from years 1 to 2
+end simulations

--- a/examples/cap_virgin.qta
+++ b/examples/cap_virgin.qta
@@ -1,0 +1,39 @@
+start default
+
+  define application "test"
+
+    uses substance "test"
+      enable domestic
+      enable import
+      initial charge with 2 kg / unit for domestic
+      initial charge with 2 kg / unit for import
+      recharge 10% each year with 1 kg / unit
+      set domestic to 100 kg during year 1
+      set import to 50 kg during year 1
+      set virgin to 150 kg during year 1
+      equals 5 tCO2e / mt
+    end substance
+
+  end application
+
+end default
+
+
+start policy "intervention"
+
+  modify application "test"
+
+    modify substance "test"
+      cap virgin to 100 kg
+    end substance
+
+  end application
+
+end policy
+
+
+start simulations
+
+  simulate "result" using "intervention" from years 1 to 1
+
+end simulations

--- a/examples/change_virgin.qta
+++ b/examples/change_virgin.qta
@@ -1,0 +1,26 @@
+start default
+
+  define application "test"
+
+    uses substance "test"
+      enable domestic
+      enable import
+      initial charge with 1 kg / unit for domestic
+      initial charge with 1 kg / unit for import
+      set domestic to 100 mt during year 1
+      set import to 50 mt during year 1
+      set virgin to 150 mt during year 1
+      change virgin by +10 % each year during years 2 to onwards
+      equals 5 tCO2e / mt
+    end substance
+
+  end application
+
+end default
+
+
+start simulations
+
+  simulate "business as usual" from years 1 to 2
+
+end simulations

--- a/examples/floor_virgin.qta
+++ b/examples/floor_virgin.qta
@@ -1,0 +1,39 @@
+start default
+
+  define application "test"
+
+    uses substance "test"
+      enable domestic
+      enable import
+      initial charge with 2 kg / unit for domestic
+      initial charge with 2 kg / unit for import
+      recharge 10% each year with 1 kg / unit
+      set domestic to 10 kg during year 1
+      set import to 5 kg during year 1
+      set virgin to 15 kg during year 1
+      equals 5 tCO2e / mt
+    end substance
+
+  end application
+
+end default
+
+
+start policy "intervention"
+
+  modify application "test"
+
+    modify substance "test"
+      floor virgin to 20 kg
+    end substance
+
+  end application
+
+end policy
+
+
+start simulations
+
+  simulate "result" using "intervention" from years 1 to 1
+
+end simulations

--- a/examples/replace_virgin.qta
+++ b/examples/replace_virgin.qta
@@ -1,0 +1,49 @@
+start default
+
+  define application "test"
+
+    uses substance "a"
+      enable domestic
+      enable import
+      initial charge with 1 kg / unit for domestic
+      initial charge with 1 kg / unit for import
+      set domestic to 50 mt during year 1
+      set import to 50 mt during year 1
+      set virgin to 100 mt during year 1
+      equals 10 tCO2e / mt
+    end substance
+
+    uses substance "b"
+      enable domestic
+      enable import
+      initial charge with 1 kg / unit for domestic
+      initial charge with 1 kg / unit for import
+      set domestic to 50 mt during year 1
+      set import to 50 mt during year 1
+      set virgin to 100 mt during year 1
+      equals 5 tCO2e / mt
+    end substance
+
+  end application
+
+end default
+
+
+start policy "intervention"
+
+  modify application "test"
+
+    modify substance "a"
+      replace 50 % of virgin with "b"
+    end substance
+
+  end application
+
+end policy
+
+
+start simulations
+
+  simulate "result" using "intervention" from years 1 to 1
+
+end simulations

--- a/examples/replace_virgin_recycling.qta
+++ b/examples/replace_virgin_recycling.qta
@@ -1,0 +1,50 @@
+start default
+
+  define application "test"
+
+    uses substance "a"
+      enable domestic
+      enable import
+      initial charge with 1 kg / unit for domestic
+      initial charge with 1 kg / unit for import
+      set domestic to 50 mt during year 1
+      set import to 50 mt during year 1
+      set virgin to 100 mt during year 1
+      equals 10 tCO2e / mt
+    end substance
+
+    uses substance "recycling"
+      enable domestic
+      enable import
+      initial charge with 1 kg / unit for domestic
+      initial charge with 1 kg / unit for import
+      set domestic to 50 mt during year 1
+      set import to 50 mt during year 1
+      set virgin to 100 mt during year 1
+      recover 20 % with 90 % reuse with 100 % induction during year 1
+      equals 5 tCO2e / mt
+    end substance
+
+  end application
+
+end default
+
+
+start policy "intervention"
+
+  modify application "test"
+
+    modify substance "a"
+      replace 50 % of virgin with "recycling"
+    end substance
+
+  end application
+
+end policy
+
+
+start simulations
+
+  simulate "result" using "intervention" from years 1 to 1
+
+end simulations

--- a/examples/set_virgin.qta
+++ b/examples/set_virgin.qta
@@ -1,0 +1,26 @@
+start default
+
+  define application "Test"
+
+    uses substance "SubA"
+      enable domestic
+      enable import
+      initial charge with 1 kg / unit for domestic
+      initial charge with 1 kg / unit for import
+      set domestic to 0.5 mt during year 1
+      set import to 0.5 mt during year 1
+      set virgin to 1 mt during year 1
+      equals 1 tCO2e / kg
+    end substance
+
+  end application
+
+end default
+
+
+start simulations
+
+  simulate "BAU"
+  from years 1 to 10
+
+end simulations

--- a/examples/ui/bau_virgin.qta
+++ b/examples/ui/bau_virgin.qta
@@ -1,0 +1,23 @@
+start default
+
+  define application "app1"
+
+    uses substance "sub1"
+      enable domestic
+      enable import
+      initial charge with 5 kg / unit for domestic
+      initial charge with 5 kg / unit for import
+      set virgin to 100 mt
+      equals 5 tCO2e / mt
+    end substance
+
+  end application
+
+end default
+
+
+start simulations
+
+  simulate "business as usual" from years 1 to 5
+
+end simulations

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -76,7 +76,7 @@ The `assume` command provides control over sales carryover behavior:
 - `assume only recharge [stream] <during>` - Sets stream to 0 units (only recharge, no new equipment)
 - `assume continued [stream] <during>` - No-op (sales continue from previous year, default behavior)
 
-Streams supported: `domestic`, `import`, `sales`, `bank`
+Streams supported: `domestic`, `import`, `sales`, `virgin`, `bank`
 
 Examples:
 ```qubectalk
@@ -114,7 +114,7 @@ Kigali Sim uses DecimalFormat number formatting (comma for thousands, period for
 
 #### Advanced Features
 - **Variables**: `define identifier as expression` and `get identifier` (scoped to enclosing start/end block)
-- **Stream access**: `get {stream}` - access streams like `sales`, `equipment`, `age`, etc.
+- **Stream access**: `get {stream}` - access streams like `sales`, `virgin`, `equipment`, `age`, etc.
 - **Unit conversions**: `get {stream} as {units}` like `get import of "substance" as mt` or `get age as years`
 - **Age stream**: `get age as years` provides weighted average equipment age for age-dependent policies (read-only, computed)
 - **Constraints**: `limit expression to [min,max]`, `limit expression to [,max]` (min of negative infinity), `limit expression to [min,]` (max of infinity)
@@ -135,11 +135,12 @@ Keywords `at` and `eol` are available for recycling commands. Use `at recharge` 
 No duration means runs each year. Use `during year beginning` for first year only.
 
 ### Streams
-Streams may be `domestic|import|export|sales|equipment|priorEquipment|bank|age`
+Streams may be `domestic|import|export|sales|virgin|equipment|priorEquipment|bank|age`
 
 - `domestic`: domestically produced and consumed
 - `import`: imported either in vessel or initial charge
 - `sales`: all consumption in country
+- `virgin`: domestic and import only (excludes recycling and exports)
 - `priorEquipment`: equipment active coming into current year
 - `equipment`: equipment active, either from prior or new
 - `age`: weighted average equipment age (read-only, Advanced Editor only)
@@ -158,7 +159,14 @@ Includes domestic, import, and recycling if active. Excludes export.
  - `set` / `change` sales impacts all consumption but recycling is limited by the recover command so domestic and import will be modified to satisfy command.
  - `cap` / `floor` place lower or upper limits on all consumption including recycling.
 
-For virgin only, replace `sales` with individual commands on `domestic` and `import` to exclude secondary.
+ For virgin only, use the `virgin` keyword which includes domestic and import but excludes secondary, or replace `sales` with individual commands on `domestic` and `import` to exclude secondary.
+
+#### Virgin
+Includes domestic and import only. Excludes both recycling and exports.
+
+ - `set` / `change` virgin impacts domestic and import proportionally without subtracting recycling.
+ - `cap` / `floor` place lower or upper limits on domestic and import only (excluding recycling).
+ - Recycling is bound by amount captured through the `recover` command.
 
 #### Age
 The `age` stream tracks the weighted average age of equipment in the population. This is a computed, read-only stream that cannot be set by users:
@@ -223,7 +231,7 @@ The `recover` command supports specifying when recycling occurs and how much ind
 - **Non-units specs (kg/mt)**: Default 100% induction (induced demand behavior) - recycling adds on top of existing demand
 - **Explicit specification**: Users can override defaults by specifying exact percentages (0-100%)
 
-**100% Induction Recommendations**: 100% induction means recycled material does not displace virgin material — it adds to total supply. This is recommended when uncertain, as induction is a complex economic phenomenon. It can be paired with caps on virgin material (import, domestic) to ensure desired reductions alongside expanded recycling.
+**100% Induction Recommendations**: 100% induction means recycled material does not displace virgin material — it adds to total supply. This is recommended when uncertain, as induction is a complex economic phenomenon. It can be paired with caps on the `virgin` stream (domestic + import) to ensure desired reductions alongside expanded recycling.
 
 Examples:
 ```


### PR DESCRIPTION
Add support for the `virgin` keyword which refers to `domestic` and `import` without `recycling`. Closes #733. Note: This used `GLM-5.1` LLM assistance.