### PR TITLE
Address PR 808 review feedback: restrict recharge of-target, add test…

### DIFF
--- a/docs/guide/glossary.html
+++ b/docs/guide/glossary.html
@@ -156,7 +156,7 @@
           <dd>A HyperTalk-inspired domain-specific language for defining simulations in Kigali Sim. Features human-readable natural language constructs and supports both basic operations and advanced features like variables, conditionals, and probabilistic sampling.</dd>
 
           <dt>Recharge</dt>
-          <dd>Servicing or refilling of existing equipment with substance due to leakage or maintenance needs. Specified using <code>recharge percentage % with amount kg / unit</code> which is equivalent to <code>recharge percentage % of priorEquipment with amount kg / unit</code>. Represents the percentage of equipment serviced and the amount per unit. By default operates on prior equipment (priorEquipment); use <code>of newEquipment</code> for precharge.</dd>
+          <dd>Servicing or refilling of existing equipment with substance due to leakage or maintenance needs. Specified using <code>recharge percentage % with amount kg / unit</code>, or equivalently <code>recharge percentage % of priorEquipment with amount kg / unit</code> (the default target). Use <code>of newEquipment</code> for precharge instead.</dd>
 
           <dt>Precharge</dt>
           <dd>Servicing of new equipment before its sale, modeling substance needed for charge lost in transit or storage. Specified using <code>recharge percentage % of newEquipment with amount kg / unit</code>. Precharge emissions are included in the rechargeEmissions metric.</dd>

--- a/engine/src/main/antlr/org/kigalisim/lang/QubecTalk.g4
+++ b/engine/src/main/antlr/org/kigalisim/lang/QubecTalk.g4
@@ -368,6 +368,8 @@ expression: number  # simpleExpression
 
 stream: (PRIOR_EQUIPMENT_ | NEW_EQUIPMENT_ | EQUIPMENT_ | BANK_ | PRIOR_BANK_ | EXPORT_ | IMPORT_ | DOMESTIC_ | SALES_ | VIRGIN_ | AGE_);
 
+rechargeTarget: (PRIOR_EQUIPMENT_ | NEW_EQUIPMENT_);
+
 identifier: IDENTIFIER_  # identifierAsVar;
 
 /**
@@ -437,8 +439,8 @@ initialChargeStatement: INITIAL_ CHARGE_ WITH_ value=unitValue FOR_ target=strea
 
 rechargeStatement: RECHARGE_ population=unitValue WITH_ volume=unitValue  # rechargeAllYears
   | RECHARGE_ population=unitValue WITH_ volume=unitValue duration=during  # rechargeDuration
-  | RECHARGE_ population=unitValue OF_ target=stream WITH_ volume=unitValue  # rechargeAllYearsWithTarget
-  | RECHARGE_ population=unitValue OF_ target=stream WITH_ volume=unitValue duration=during  # rechargeDurationWithTarget
+  | RECHARGE_ population=unitValue OF_ target=rechargeTarget WITH_ volume=unitValue  # rechargeAllYearsWithTarget
+  | RECHARGE_ population=unitValue OF_ target=rechargeTarget WITH_ volume=unitValue duration=during  # rechargeDurationWithTarget
   ;
 
 recycleStatement: RECOVER_ volume=unitValue WITH_ yieldVal=unitValue REUSE_                                                        # recoverAllYears

--- a/engine/src/main/java/org/kigalisim/engine/SingleThreadEngine.java
+++ b/engine/src/main/java/org/kigalisim/engine/SingleThreadEngine.java
@@ -879,6 +879,14 @@ public class SingleThreadEngine implements Engine {
    * during carry-over scenarios where no fresh specification exists, or during precharge
    * when a last specified sales value is available.</p>
    *
+   * <p>Precharge and recharge are intentionally asymmetric here. Recharge's population baseline
+   * (priorEquipment) is a persistent stream independent of this year's sales specification, so it
+   * can be re-derived from current state and only needs to replay the last sales value on true
+   * carry-over years. Precharge has no such independent baseline: new equipment is whatever this
+   * year's sales intent implies, so replaying the last specified value (fresh or carried over)
+   * is required whenever one is available, since the precharge configuration can change
+   * independent of whether sales was freshly specified.</p>
+   *
    * @param isCarryOver true if this is a carry-over scenario
    * @param isPrecharge true if this is a precharge operation
    * @param simulationState the current simulation state

--- a/engine/src/main/java/org/kigalisim/engine/recalc/SalesRecalcStrategy.java
+++ b/engine/src/main/java/org/kigalisim/engine/recalc/SalesRecalcStrategy.java
@@ -121,7 +121,6 @@ public class SalesRecalcStrategy implements RecalcStrategy {
         .setSimulationState(simulationState)
         .setScopeEffective(scopeEffective)
         .build();
-    BigDecimal requiredKg = demandAnalysis.getTotalDemand();
     boolean hasUnitBasedSpecs = demandAnalysis.getHadUnitBasedSpecs();
     BigDecimal totalRequiredKg = demandAnalysis.getRequiredVirginMaterial();
 

--- a/engine/src/main/java/org/kigalisim/engine/recalc/util/DemandAnalysisBuilder.java
+++ b/engine/src/main/java/org/kigalisim/engine/recalc/util/DemandAnalysisBuilder.java
@@ -14,6 +14,7 @@ package org.kigalisim.engine.recalc.util;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
+import java.util.Optional;
 import org.kigalisim.engine.number.EngineNumber;
 import org.kigalisim.engine.state.SimulationState;
 import org.kigalisim.engine.state.UseKey;
@@ -143,6 +144,8 @@ public class DemandAnalysisBuilder {
    * @return A DemandAnalysis containing the computed demand, spec type, and virgin material
    */
   public DemandAnalysis build() {
+    validate();
+
     BigDecimal totalDemand = calculateTotalDemand();
     boolean hasUnitBasedSpecs = getHasUnitBasedSpecs();
     BigDecimal requiredVirginMaterial = calculateRequiredVirginMaterial(
@@ -150,6 +153,39 @@ public class DemandAnalysisBuilder {
         hasUnitBasedSpecs
     );
     return new DemandAnalysis(totalDemand, hasUnitBasedSpecs, requiredVirginMaterial);
+  }
+
+  /**
+   * Validate that all fields required to build a DemandAnalysis have been set.
+   *
+   * <p>Fails fast with a clear message instead of letting a missing field surface later as a
+   * {@link NullPointerException} deep inside demand calculation.</p>
+   *
+   * @throws IllegalStateException if a required field is missing
+   */
+  private void validate() {
+    requireField(rechargeVolume, "rechargeVolume");
+    requireField(prechargeVolume, "prechargeVolume");
+    requireField(volumeForNew, "volumeForNew");
+    requireField(implicitRechargeKg, "implicitRechargeKg");
+    requireField(implicitPrechargeKg, "implicitPrechargeKg");
+    requireField(eolRecycledKg, "eolRecycledKg");
+    requireField(rechargeRecycledKg, "rechargeRecycledKg");
+    requireField(simulationState, "simulationState");
+    requireField(scopeEffective, "scopeEffective");
+  }
+
+  /**
+   * Require that a builder field was set before {@link #build()} was called.
+   *
+   * @param value The field value to check
+   * @param fieldName The name of the field, used in the error message
+   * @throws IllegalStateException if value is empty
+   */
+  private void requireField(Object value, String fieldName) {
+    if (Optional.ofNullable(value).isEmpty()) {
+      throw new IllegalStateException(fieldName + " is required to build a DemandAnalysis");
+    }
   }
 
   /**

--- a/engine/src/main/java/org/kigalisim/engine/recalc/util/DemandAnalysisBuilder.java
+++ b/engine/src/main/java/org/kigalisim/engine/recalc/util/DemandAnalysisBuilder.java
@@ -14,7 +14,6 @@ package org.kigalisim.engine.recalc.util;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
-import java.util.Optional;
 import org.kigalisim.engine.number.EngineNumber;
 import org.kigalisim.engine.state.SimulationState;
 import org.kigalisim.engine.state.UseKey;
@@ -24,7 +23,7 @@ import org.kigalisim.lang.operation.RecoverOperation.RecoveryStage;
 /**
  * Builder for demand analysis calculations in sales recalculation.
  */
-public class DemandAnalysisBuilder {
+public class DemandAnalysisBuilder extends ValidatedBuilder<DemandAnalysis> {
 
   private EngineNumber rechargeVolume;
   private EngineNumber prechargeVolume;
@@ -35,6 +34,13 @@ public class DemandAnalysisBuilder {
   private BigDecimal rechargeRecycledKg;
   private SimulationState simulationState;
   private UseKey scopeEffective;
+
+  /**
+   * Create a new DemandAnalysisBuilder.
+   */
+  public DemandAnalysisBuilder() {
+    super("DemandAnalysis");
+  }
 
   /**
    * Set the recharge volume.
@@ -143,9 +149,8 @@ public class DemandAnalysisBuilder {
    *
    * @return A DemandAnalysis containing the computed demand, spec type, and virgin material
    */
-  public DemandAnalysis build() {
-    validate();
-
+  @Override
+  protected DemandAnalysis buildInternal() {
     BigDecimal totalDemand = calculateTotalDemand();
     boolean hasUnitBasedSpecs = getHasUnitBasedSpecs();
     BigDecimal requiredVirginMaterial = calculateRequiredVirginMaterial(
@@ -163,7 +168,8 @@ public class DemandAnalysisBuilder {
    *
    * @throws IllegalStateException if a required field is missing
    */
-  private void validate() {
+  @Override
+  protected void validate() {
     requireField(rechargeVolume, "rechargeVolume");
     requireField(prechargeVolume, "prechargeVolume");
     requireField(volumeForNew, "volumeForNew");
@@ -173,19 +179,6 @@ public class DemandAnalysisBuilder {
     requireField(rechargeRecycledKg, "rechargeRecycledKg");
     requireField(simulationState, "simulationState");
     requireField(scopeEffective, "scopeEffective");
-  }
-
-  /**
-   * Require that a builder field was set before {@link #build()} was called.
-   *
-   * @param value The field value to check
-   * @param fieldName The name of the field, used in the error message
-   * @throws IllegalStateException if value is empty
-   */
-  private void requireField(Object value, String fieldName) {
-    if (Optional.ofNullable(value).isEmpty()) {
-      throw new IllegalStateException(fieldName + " is required to build a DemandAnalysis");
-    }
   }
 
   /**

--- a/engine/src/main/java/org/kigalisim/engine/recalc/util/ServicingOffsetBuilder.java
+++ b/engine/src/main/java/org/kigalisim/engine/recalc/util/ServicingOffsetBuilder.java
@@ -28,8 +28,8 @@ public class ServicingOffsetBuilder extends ValidatedBuilder<ServicingOffset> {
   private BigDecimal salesKg;
   private BigDecimal rechargeKg;
   private BigDecimal initialChargeKgUnit;
-  private EngineNumber prechargePopRaw;
-  private EngineNumber prechargeIntensityRaw;
+  private Optional<EngineNumber> prechargePopRaw;
+  private Optional<EngineNumber> prechargeIntensityRaw;
   private boolean useExplicitRechargeEffective;
   private BigDecimal implicitPrechargeKg;
   private StateGetter stateGetter;
@@ -39,6 +39,8 @@ public class ServicingOffsetBuilder extends ValidatedBuilder<ServicingOffset> {
    */
   public ServicingOffsetBuilder() {
     super("ServicingOffset");
+    prechargePopRaw = Optional.empty();
+    prechargeIntensityRaw = Optional.empty();
   }
 
   /**
@@ -81,7 +83,7 @@ public class ServicingOffsetBuilder extends ValidatedBuilder<ServicingOffset> {
    * @return This builder for chaining
    */
   public ServicingOffsetBuilder setPrechargePopRaw(EngineNumber prechargePopRaw) {
-    this.prechargePopRaw = prechargePopRaw;
+    this.prechargePopRaw = Optional.ofNullable(prechargePopRaw);
     return this;
   }
 
@@ -92,7 +94,7 @@ public class ServicingOffsetBuilder extends ValidatedBuilder<ServicingOffset> {
    * @return This builder for chaining
    */
   public ServicingOffsetBuilder setPrechargeIntensityRaw(EngineNumber prechargeIntensityRaw) {
-    this.prechargeIntensityRaw = prechargeIntensityRaw;
+    this.prechargeIntensityRaw = Optional.ofNullable(prechargeIntensityRaw);
     return this;
   }
 
@@ -172,13 +174,14 @@ public class ServicingOffsetBuilder extends ValidatedBuilder<ServicingOffset> {
     requireField(rechargeKg, "rechargeKg");
     requireField(initialChargeKgUnit, "initialChargeKgUnit");
 
-    boolean hasNonZeroPrechargePop = Optional.ofNullable(prechargePopRaw)
+    boolean hasNonZeroPrechargePop = prechargePopRaw
         .map(EngineNumber::getValue)
         .filter(value -> value.compareTo(BigDecimal.ZERO) != 0)
         .isPresent();
-    if (hasNonZeroPrechargePop && Optional.ofNullable(prechargeIntensityRaw).isEmpty()) {
+    if (hasNonZeroPrechargePop && prechargeIntensityRaw.isEmpty()) {
       throw new IllegalStateException(
-          "prechargeIntensityRaw is required when prechargePopRaw is non-zero");
+          "prechargeIntensityRaw is required when prechargePopRaw is non-zero"
+      );
     }
   }
 
@@ -188,14 +191,15 @@ public class ServicingOffsetBuilder extends ValidatedBuilder<ServicingOffset> {
    * @return A ServicingStatus describing the precharge configuration
    */
   private ServicingStatus describeServicing() {
-    if (prechargePopRaw == null) {
+    if (prechargePopRaw.isEmpty()) {
       return new ServicingStatus(false, false);
     } else {
-      boolean hasPrecharge = prechargePopRaw.getValue().compareTo(BigDecimal.ZERO) != 0;
+      EngineNumber prechargePop = prechargePopRaw.get();
+      boolean hasPrecharge = prechargePop.getValue().compareTo(BigDecimal.ZERO) != 0;
       if (!hasPrecharge) {
         return new ServicingStatus(false, false);
       } else {
-        String units = prechargePopRaw.getUnits();
+        String units = prechargePop.getUnits();
         boolean isPercent = units != null && units.contains("%");
         return new ServicingStatus(true, isPercent);
       }
@@ -213,9 +217,9 @@ public class ServicingOffsetBuilder extends ValidatedBuilder<ServicingOffset> {
    * @return A ServicingOffset with the computed deltaUnits and prechargeKg
    */
   private ServicingOffset offsetVolumeSalesPercentPrecharge() {
-    BigDecimal prechargeRatio = prechargePopRaw.getValue()
+    BigDecimal prechargeRatio = prechargePopRaw.get().getValue()
         .divide(BigDecimal.valueOf(100), MathContext.DECIMAL128);
-    BigDecimal prechargeIntensityKg = prechargeIntensityRaw.getValue();
+    BigDecimal prechargeIntensityKg = prechargeIntensityRaw.get().getValue();
     BigDecimal denominator = initialChargeKgUnit
         .add(prechargeRatio.multiply(prechargeIntensityKg));
     BigDecimal deltaUnits = DivisionHelper.divideWithZero(
@@ -236,9 +240,9 @@ public class ServicingOffsetBuilder extends ValidatedBuilder<ServicingOffset> {
     OverridingConverterStateGetter prechargeStateGetter =
         new OverridingConverterStateGetter(stateGetter);
     UnitConverter prechargeConverter = new UnitConverter(prechargeStateGetter);
-    EngineNumber prechargePop = prechargeConverter.convert(prechargePopRaw, "units");
+    EngineNumber prechargePop = prechargeConverter.convert(prechargePopRaw.get(), "units");
     prechargeStateGetter.setPopulation(prechargePop);
-    EngineNumber prechargeVolume = prechargeConverter.convert(prechargeIntensityRaw, "kg");
+    EngineNumber prechargeVolume = prechargeConverter.convert(prechargeIntensityRaw.get(), "kg");
     prechargeStateGetter.clearPopulation();
     BigDecimal prechargeKg = prechargeVolume.getValue();
     BigDecimal availableForNewUnitsKg = salesKg.subtract(rechargeKg).subtract(prechargeKg);

--- a/engine/src/main/java/org/kigalisim/engine/recalc/util/ServicingOffsetBuilder.java
+++ b/engine/src/main/java/org/kigalisim/engine/recalc/util/ServicingOffsetBuilder.java
@@ -13,6 +13,7 @@ package org.kigalisim.engine.recalc.util;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
+import java.util.Optional;
 import org.kigalisim.engine.number.EngineNumber;
 import org.kigalisim.engine.number.UnitConverter;
 import org.kigalisim.engine.state.OverridingConverterStateGetter;
@@ -133,6 +134,8 @@ public class ServicingOffsetBuilder {
    * @return A ServicingOffset with deltaUnits, prechargeKg, and rechargeKg
    */
   public ServicingOffset build() {
+    validate();
+
     ServicingStatus servicingStatus = describeServicing();
     boolean isServicingEnabled = servicingStatus.isServicingEnabled();
     boolean isPercentPopulation = servicingStatus.isPercentPopulation();
@@ -144,6 +147,44 @@ public class ServicingOffsetBuilder {
       return offsetVolumeSalesExplicitPrecharge();
     } else {
       return offsetUnitSales();
+    }
+  }
+
+  /**
+   * Validate the fields required by every branch of servicing offset calculation.
+   *
+   * <p>Fields only needed by a specific branch (such as {@code stateGetter} for explicit
+   * precharge or {@code implicitPrechargeKg} for unit-based sales) are validated lazily by that
+   * branch instead, since which branch runs depends on the other fields set here.</p>
+   *
+   * @throws IllegalStateException if a required field is missing or precharge population and
+   *     intensity were not set together
+   */
+  private void validate() {
+    requireField(salesKg, "salesKg");
+    requireField(rechargeKg, "rechargeKg");
+    requireField(initialChargeKgUnit, "initialChargeKgUnit");
+
+    boolean hasNonZeroPrechargePop = Optional.ofNullable(prechargePopRaw)
+        .map(EngineNumber::getValue)
+        .filter(value -> value.compareTo(BigDecimal.ZERO) != 0)
+        .isPresent();
+    if (hasNonZeroPrechargePop && Optional.ofNullable(prechargeIntensityRaw).isEmpty()) {
+      throw new IllegalStateException(
+          "prechargeIntensityRaw is required when prechargePopRaw is non-zero");
+    }
+  }
+
+  /**
+   * Require that a builder field was set before {@link #build()} was called.
+   *
+   * @param value The field value to check
+   * @param fieldName The name of the field, used in the error message
+   * @throws IllegalStateException if value is empty
+   */
+  private void requireField(Object value, String fieldName) {
+    if (Optional.ofNullable(value).isEmpty()) {
+      throw new IllegalStateException(fieldName + " is required to build a ServicingOffset");
     }
   }
 
@@ -197,6 +238,7 @@ public class ServicingOffsetBuilder {
    * @return A ServicingOffset with the computed deltaUnits and prechargeKg
    */
   private ServicingOffset offsetVolumeSalesExplicitPrecharge() {
+    requireField(stateGetter, "stateGetter");
     OverridingConverterStateGetter prechargeStateGetter =
         new OverridingConverterStateGetter(stateGetter);
     UnitConverter prechargeConverter = new UnitConverter(prechargeStateGetter);
@@ -219,6 +261,7 @@ public class ServicingOffsetBuilder {
    * @return A ServicingOffset with the computed deltaUnits and prechargeKg
    */
   private ServicingOffset offsetUnitSales() {
+    requireField(implicitPrechargeKg, "implicitPrechargeKg");
     BigDecimal prechargeKg = implicitPrechargeKg;
     BigDecimal availableForNewUnitsKg = salesKg.subtract(rechargeKg).subtract(prechargeKg);
     BigDecimal deltaUnits = DivisionHelper.divideWithZero(

--- a/engine/src/main/java/org/kigalisim/engine/recalc/util/ServicingOffsetBuilder.java
+++ b/engine/src/main/java/org/kigalisim/engine/recalc/util/ServicingOffsetBuilder.java
@@ -23,7 +23,7 @@ import org.kigalisim.engine.support.DivisionHelper;
 /**
  * Builder that calculates servicing (precharge/recharge) offsets for population changes.
  */
-public class ServicingOffsetBuilder {
+public class ServicingOffsetBuilder extends ValidatedBuilder<ServicingOffset> {
 
   private BigDecimal salesKg;
   private BigDecimal rechargeKg;
@@ -33,6 +33,13 @@ public class ServicingOffsetBuilder {
   private boolean useExplicitRechargeEffective;
   private BigDecimal implicitPrechargeKg;
   private StateGetter stateGetter;
+
+  /**
+   * Create a new ServicingOffsetBuilder.
+   */
+  public ServicingOffsetBuilder() {
+    super("ServicingOffset");
+  }
 
   /**
    * Set the total substance sales volume in kilograms.
@@ -133,9 +140,8 @@ public class ServicingOffsetBuilder {
    *
    * @return A ServicingOffset with deltaUnits, prechargeKg, and rechargeKg
    */
-  public ServicingOffset build() {
-    validate();
-
+  @Override
+  protected ServicingOffset buildInternal() {
     ServicingStatus servicingStatus = describeServicing();
     boolean isServicingEnabled = servicingStatus.isServicingEnabled();
     boolean isPercentPopulation = servicingStatus.isPercentPopulation();
@@ -160,7 +166,8 @@ public class ServicingOffsetBuilder {
    * @throws IllegalStateException if a required field is missing or precharge population and
    *     intensity were not set together
    */
-  private void validate() {
+  @Override
+  protected void validate() {
     requireField(salesKg, "salesKg");
     requireField(rechargeKg, "rechargeKg");
     requireField(initialChargeKgUnit, "initialChargeKgUnit");
@@ -172,19 +179,6 @@ public class ServicingOffsetBuilder {
     if (hasNonZeroPrechargePop && Optional.ofNullable(prechargeIntensityRaw).isEmpty()) {
       throw new IllegalStateException(
           "prechargeIntensityRaw is required when prechargePopRaw is non-zero");
-    }
-  }
-
-  /**
-   * Require that a builder field was set before {@link #build()} was called.
-   *
-   * @param value The field value to check
-   * @param fieldName The name of the field, used in the error message
-   * @throws IllegalStateException if value is empty
-   */
-  private void requireField(Object value, String fieldName) {
-    if (Optional.ofNullable(value).isEmpty()) {
-      throw new IllegalStateException(fieldName + " is required to build a ServicingOffset");
     }
   }
 

--- a/engine/src/main/java/org/kigalisim/engine/recalc/util/ValidatedBuilder.java
+++ b/engine/src/main/java/org/kigalisim/engine/recalc/util/ValidatedBuilder.java
@@ -1,0 +1,73 @@
+/**
+ * Base class for builders that validate required fields before constructing their result.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.kigalisim.engine.recalc.util;
+
+import java.util.Optional;
+
+/**
+ * Base class for builders that validate required fields before constructing their result.
+ *
+ * <p>Subclasses implement {@link #validate()} to check fields required by every build path, and
+ * {@link #buildInternal()} to construct the result. Fields required only by a specific branch of
+ * construction logic can call {@link #requireField(Object, String)} directly from within that
+ * branch instead of (or in addition to) {@link #validate()}, so validation can be deferred until
+ * it is known that branch will actually run.</p>
+ *
+ * @param <T> The type of object this builder builds
+ */
+public abstract class ValidatedBuilder<T> {
+
+  private final String builtTypeName;
+
+  /**
+   * Create a new ValidatedBuilder.
+   *
+   * @param builtTypeName The name of the type this builder builds, used in validation error
+   *     messages
+   */
+  protected ValidatedBuilder(String builtTypeName) {
+    this.builtTypeName = builtTypeName;
+  }
+
+  /**
+   * Validate required fields and build the result.
+   *
+   * @return The built result
+   * @throws IllegalStateException if a required field is missing
+   */
+  public final T build() {
+    validate();
+    return buildInternal();
+  }
+
+  /**
+   * Validate the fields required by every build path.
+   *
+   * @throws IllegalStateException if a required field is missing
+   */
+  protected abstract void validate();
+
+  /**
+   * Construct the result after {@link #validate()} has passed.
+   *
+   * @return The built result
+   */
+  protected abstract T buildInternal();
+
+  /**
+   * Require that a builder field was set before building.
+   *
+   * @param value The field value to check
+   * @param fieldName The name of the field, used in the error message
+   * @throws IllegalStateException if value is empty
+   */
+  protected void requireField(Object value, String fieldName) {
+    if (Optional.ofNullable(value).isEmpty()) {
+      throw new IllegalStateException(fieldName + " is required to build a " + builtTypeName);
+    }
+  }
+}

--- a/engine/src/main/java/org/kigalisim/lang/QubecTalkEngineVisitor.java
+++ b/engine/src/main/java/org/kigalisim/lang/QubecTalkEngineVisitor.java
@@ -929,7 +929,7 @@ public class QubecTalkEngineVisitor extends QubecTalkBaseVisitor<Fragment> {
       QubecTalkParser.RechargeAllYearsWithTargetContext ctx) {
     Operation populationOperation = visit(ctx.population).getOperation();
     Operation volumeOperation = visit(ctx.volume).getOperation();
-    String target = applyStreamSugar(ctx.target.getText());
+    String target = ctx.target.getText();
     Operation operation = new RechargeOperation(
         populationOperation,
         volumeOperation,
@@ -948,7 +948,7 @@ public class QubecTalkEngineVisitor extends QubecTalkBaseVisitor<Fragment> {
     Operation populationOperation = visit(ctx.population).getOperation();
     Operation volumeOperation = visit(ctx.volume).getOperation();
     ParsedDuring during = visit(ctx.duration).getDuring();
-    String target = applyStreamSugar(ctx.target.getText());
+    String target = ctx.target.getText();
     Operation operation = new RechargeOperation(
         populationOperation,
         volumeOperation,

--- a/engine/src/test/java/org/kigalisim/engine/recalc/util/DemandAnalysisBuilderTest.java
+++ b/engine/src/test/java/org/kigalisim/engine/recalc/util/DemandAnalysisBuilderTest.java
@@ -1,0 +1,42 @@
+/**
+ * Unit tests for the DemandAnalysisBuilder class.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.kigalisim.engine.recalc.util;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+import org.kigalisim.engine.number.EngineNumber;
+
+/**
+ * Tests for the DemandAnalysisBuilder class.
+ */
+public class DemandAnalysisBuilderTest {
+
+  /**
+   * Test that build() fails fast with a clear message when a required field (such as
+   * rechargeVolume) is missing, instead of a NullPointerException surfacing later.
+   */
+  @Test
+  public void testBuildFailsFastWhenRequiredFieldMissing() {
+    IllegalStateException exception = assertThrows(
+        IllegalStateException.class,
+        () -> new DemandAnalysisBuilder()
+            .setPrechargeVolume(new EngineNumber(BigDecimal.ZERO, "kg"))
+            .setVolumeForNew(new EngineNumber(BigDecimal.ZERO, "kg"))
+            .setImplicitRechargeKg(BigDecimal.ZERO)
+            .setImplicitPrechargeKg(BigDecimal.ZERO)
+            .setEolRecycledKg(BigDecimal.ZERO)
+            .setRechargeRecycledKg(BigDecimal.ZERO)
+            .build(),
+        "Should throw IllegalStateException when rechargeVolume is not set"
+    );
+    assertTrue(exception.getMessage().contains("rechargeVolume"),
+        "Error message should mention the missing field (rechargeVolume)");
+  }
+}

--- a/engine/src/test/java/org/kigalisim/engine/recalc/util/ServicingOffsetBuilderTest.java
+++ b/engine/src/test/java/org/kigalisim/engine/recalc/util/ServicingOffsetBuilderTest.java
@@ -7,6 +7,8 @@
 package org.kigalisim.engine.recalc.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 
@@ -129,6 +131,37 @@ public class ServicingOffsetBuilderTest {
         "Delta units should be 60 in circular case");
     assertBigDecimalEquals(new BigDecimal("60"), offset.getPrechargeKg(),
         "Precharge kg should be 60 in circular case");
+  }
+
+  /**
+   * Test the circular case with 100% precharge population.
+   *
+   * <p>With 100% precharge, 2 kg/unit intensity, 100 kg sales, 10 kg recharge, and 1 kg/unit
+   * initial charge: prechargeRatio = 1.0, denominator = 1 + 1.0 * 2 = 3, deltaUnits = 90 / 3 =
+   * 30, prechargeKg = 30 * 1.0 * 2 = 60.</p>
+   */
+  @Test
+  public void testOffsetVolumeSalesFullPrecharge() {
+    BigDecimal salesKg = new BigDecimal("100");
+    BigDecimal rechargeKg = new BigDecimal("10");
+    BigDecimal initialChargeKgUnit = new BigDecimal("1");
+    EngineNumber prechargePopRaw = new EngineNumber(new BigDecimal("100"), "%");
+    EngineNumber prechargeIntensityRaw = new EngineNumber(new BigDecimal("2"), "kg / unit");
+
+    ServicingOffset offset = new ServicingOffsetBuilder()
+        .setSalesKg(salesKg)
+        .setRechargeKg(rechargeKg)
+        .setInitialChargeKgUnit(initialChargeKgUnit)
+        .setPrechargePopRaw(prechargePopRaw)
+        .setPrechargeIntensityRaw(prechargeIntensityRaw)
+        .setUseExplicitRechargeEffective(true)
+        .setImplicitPrechargeKg(BigDecimal.ZERO)
+        .build();
+
+    assertBigDecimalEquals(new BigDecimal("30"), offset.getDeltaUnits(),
+        "Delta units should be 30 when precharge population is 100%");
+    assertBigDecimalEquals(new BigDecimal("60"), offset.getPrechargeKg(),
+        "Precharge kg should be 60 when precharge population is 100%");
   }
 
   /**
@@ -306,5 +339,74 @@ public class ServicingOffsetBuilderTest {
         "Delta units should be zero with no sales");
     assertBigDecimalEquals(BigDecimal.ZERO, offset.getPrechargeKg(),
         "Precharge kg should be zero with no implicit precharge");
+  }
+
+  /**
+   * Test that build() fails fast with a clear message when a field required by every branch
+   * (such as salesKg) is missing, instead of a NullPointerException surfacing later.
+   */
+  @Test
+  public void testBuildFailsFastWhenAlwaysRequiredFieldMissing() {
+    IllegalStateException exception = assertThrows(
+        IllegalStateException.class,
+        () -> new ServicingOffsetBuilder()
+            .setRechargeKg(BigDecimal.ZERO)
+            .setInitialChargeKgUnit(BigDecimal.ONE)
+            .setUseExplicitRechargeEffective(false)
+            .setImplicitPrechargeKg(BigDecimal.ZERO)
+            .build(),
+        "Should throw IllegalStateException when salesKg is not set"
+    );
+    assertTrue(exception.getMessage().contains("salesKg"),
+        "Error message should mention the missing field (salesKg)");
+  }
+
+  /**
+   * Test that build() fails fast when prechargePopRaw is set but prechargeIntensityRaw is not.
+   */
+  @Test
+  public void testBuildFailsFastWhenPrechargeIntensityMissing() {
+    EngineNumber prechargePopRaw = new EngineNumber(new BigDecimal("50"), "%");
+
+    IllegalStateException exception = assertThrows(
+        IllegalStateException.class,
+        () -> new ServicingOffsetBuilder()
+            .setSalesKg(new BigDecimal("100"))
+            .setRechargeKg(BigDecimal.ZERO)
+            .setInitialChargeKgUnit(BigDecimal.ONE)
+            .setPrechargePopRaw(prechargePopRaw)
+            .setUseExplicitRechargeEffective(true)
+            .setImplicitPrechargeKg(BigDecimal.ZERO)
+            .build(),
+        "Should throw IllegalStateException when prechargeIntensityRaw is not set"
+    );
+    assertTrue(exception.getMessage().contains("prechargeIntensityRaw"),
+        "Error message should mention the missing field (prechargeIntensityRaw)");
+  }
+
+  /**
+   * Test that build() fails fast when the explicit precharge branch is reached without a
+   * stateGetter having been set.
+   */
+  @Test
+  public void testBuildFailsFastWhenStateGetterMissingForExplicitPrecharge() {
+    EngineNumber prechargePopRaw = new EngineNumber(new BigDecimal("10"), "units");
+    EngineNumber prechargeIntensityRaw = new EngineNumber(new BigDecimal("2"), "kg / unit");
+
+    IllegalStateException exception = assertThrows(
+        IllegalStateException.class,
+        () -> new ServicingOffsetBuilder()
+            .setSalesKg(new BigDecimal("100"))
+            .setRechargeKg(new BigDecimal("10"))
+            .setInitialChargeKgUnit(BigDecimal.ONE)
+            .setPrechargePopRaw(prechargePopRaw)
+            .setPrechargeIntensityRaw(prechargeIntensityRaw)
+            .setUseExplicitRechargeEffective(true)
+            .setImplicitPrechargeKg(BigDecimal.ZERO)
+            .build(),
+        "Should throw IllegalStateException when stateGetter is not set"
+    );
+    assertTrue(exception.getMessage().contains("stateGetter"),
+        "Error message should mention the missing field (stateGetter)");
   }
 }

--- a/engine/src/test/java/org/kigalisim/validate/PrechargeGrammarTests.java
+++ b/engine/src/test/java/org/kigalisim/validate/PrechargeGrammarTests.java
@@ -7,6 +7,7 @@
 package org.kigalisim.validate;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -74,5 +75,20 @@ public class PrechargeGrammarTests {
     Stream<EngineResult> results = KigaliSimFacade.runScenario(program, scenarioName, progress -> {});
     List<EngineResult> resultsList = results.collect(Collectors.toList());
     assertTrue(resultsList.size() > 0, "Should have results for recharge of newEquipment");
+  }
+
+  /**
+   * Test that recharge with an "of" target other than priorEquipment or newEquipment
+   * is rejected at parse time.
+   */
+  @Test
+  public void testRechargeOfInvalidTargetRejected() {
+    String qtaPath = "../examples/recharge_of_invalid_target.qta";
+    assertThrows(
+        RuntimeException.class,
+        () -> KigaliSimFacade.parseAndInterpret(qtaPath),
+        "Should throw RuntimeException for 'of' clause targeting a stream other than "
+            + "priorEquipment or newEquipment"
+    );
   }
 }

--- a/engine/src/test/java/org/kigalisim/validate/PrechargeLiveTests.java
+++ b/engine/src/test/java/org/kigalisim/validate/PrechargeLiveTests.java
@@ -74,11 +74,11 @@ public class PrechargeLiveTests {
     assertEquals("units", resultYear1.getPopulation().getUnits(),
         "Equipment units should be units");
 
-    // Year 1: RechargeEmissions should be non-zero (from precharge)
+    // Year 1: RechargeEmissions should be 50 tCO2e (50 kg precharge x 1 tCO2e / kg)
     EngineNumber rechargeEmissions = resultYear1.getRechargeEmissions();
     assertNotNull(rechargeEmissions, "Recharge emissions should not be null");
-    assertTrue(rechargeEmissions.getValue().doubleValue() > 0,
-        "Recharge emissions should be positive (from precharge): " + rechargeEmissions.getValue());
+    assertEquals(50.0, rechargeEmissions.getValue().doubleValue(), 0.0001,
+        "Recharge emissions should be 50 tCO2e (from precharge)");
   }
 
   /**
@@ -100,11 +100,14 @@ public class PrechargeLiveTests {
     assertEquals(11000.0, resultYear1.getPopulation().getValue().doubleValue(), 0.0001,
         "Equipment should be 11000 units in year 1");
 
-    // Year 1: RechargeEmissions should include both recharge (prior) and precharge (new)
+    // Year 1: RechargeEmissions should include both recharge (prior) and precharge (new):
+    // recharge = 5% of 10000 prior units * 1 kg/unit = 500 kg
+    // precharge = 3% of 1000 new units * 1 kg/unit = 30 kg
+    // total = 530 kg * 1 tCO2e/kg = 530 tCO2e
     EngineNumber rechargeEmissions = resultYear1.getRechargeEmissions();
     assertNotNull(rechargeEmissions, "Recharge emissions should not be null");
-    assertTrue(rechargeEmissions.getValue().doubleValue() > 0,
-        "Recharge emissions should be positive (from both recharge and precharge)");
+    assertEquals(530.0, rechargeEmissions.getValue().doubleValue(), 0.0001,
+        "Recharge emissions should be 530 tCO2e (500 recharge + 30 precharge)");
   }
 
   /**
@@ -132,6 +135,259 @@ public class PrechargeLiveTests {
     assertTrue(resultYear2.getPopulation().getValue().doubleValue() > 11000.0,
         "Equipment should increase in year 2 due to +10% change: "
             + resultYear2.getPopulation().getValue());
+  }
+
+  /**
+   * Test precharge combined with recharge-stage recovery (recycling).
+   *
+   * <p>Setup: import = 105 kg flat (year 2021 onward), initial charge 1 kg/unit,
+   * precharge 5% of newEquipment with 1 kg/unit, and an absolute recover of
+   * 20 kg with 100% reuse and 0% induction (full displacement) every year.</p>
+   *
+   * <p>Because recovery is specified as an absolute 20 kg (not a percentage of
+   * recharge volume) and no recharge of priorEquipment is configured, the recovered
+   * amount does not depend on rechargeVolume. With 0% induction the recycled
+   * material fully displaces virgin material 1-for-1: the "sales" stream used by
+   * the population calculation (domestic + import + recycle) is unaffected by
+   * recycling, so newEquipment is identical to the no-recycling case:</p>
+   *
+   * <pre>
+   * newEquipment = (salesKg - rechargeKg) / (initialCharge + prechargeRatio * prechargeIntensity)
+   *              = (105 - 0) / (1 + 0.05 * 1) = 100 units/year
+   * </pre>
+   *
+   * <p>Only the virgin/recycled split of sales changes: virgin import = 105 - 20 =
+   * 85 kg and recycle = 20 kg, while total sales remains 105 kg.</p>
+   */
+  @Test
+  public void testPrechargeWithRecover() throws IOException {
+    String qtaPath = "../examples/precharge_with_recover.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    String scenarioName = "BAU";
+    Stream<EngineResult> results = KigaliSimFacade.runScenario(program, scenarioName, progress -> {});
+    List<EngineResult> resultsList = results.collect(Collectors.toList());
+
+    for (int year = 2021; year <= 2023; year++) {
+      EngineResult result = LiveTestsUtil.getResult(
+          resultsList.stream(), year, "Domestic Refrigeration", "HFC-134a");
+      assertNotNull(result, "Should have result for year " + year);
+
+      assertEquals(100.0, result.getPopulationNew().getValue().doubleValue(), 0.0001,
+          "newEquipment should be 100 units in year " + year
+              + " (recovery with 0% induction should not change population growth)");
+
+      assertEquals(85.0, result.getImport().getValue().doubleValue(), 0.0001,
+          "Virgin import should be 105 - 20 (recycled) = 85 kg in year " + year);
+
+      assertEquals(20.0, result.getRecycle().getValue().doubleValue(), 0.0001,
+          "Recycled amount should be 20 kg (full recovery, 100% reuse) in year " + year);
+    }
+
+    // Cumulative population should grow by the same 100 units/year increment
+    EngineResult resultYear2023 = LiveTestsUtil.getResult(
+        resultsList.stream(), 2023, "Domestic Refrigeration", "HFC-134a");
+    assertNotNull(resultYear2023, "Should have result for year 2023");
+    assertEquals(300.0, resultYear2023.getPopulation().getValue().doubleValue(), 0.0001,
+        "Population should be 300 units by year 2023 (100 units/year for 3 years)");
+  }
+
+  /**
+   * Pin down that the "sales" total stays reconciled with actual newEquipment needs
+   * even when recover (recycling) recalculation runs before the population-change
+   * closed form for the circular percent-precharge + kg-tracked-sales case.
+   *
+   * <p>Background (see issue #807 / PR #808): {@code PrechargeVolumeCalculator}, used by
+   * {@code SalesRecalcStrategy} to size domestic/import demand, reads whatever
+   * {@code newEquipment} is currently persisted in engine state rather than deriving it
+   * from the closed-form formula. For {@code recover}, the engine calls
+   * {@code recalcSales()} BEFORE {@code thenPropagateToPopulationChange()}
+   * (see {@code SingleThreadEngine.recycle}), so the precharge contribution baked into
+   * that call's sales total is based on the newEquipment count from the previous
+   * recalculation, not the one that population-change is about to compute.</p>
+   *
+   * <p>This does not manifest as an observable inconsistency: {@code
+   * PopulationChangeRecalcStrategy} always solves for newEquipment from whatever
+   * "sales" total ends up persisted using the exact closed-form denominator
+   * {@code (initialCharge + prechargeRatio * prechargeIntensity)}, so
+   * {@code domestic + import + recycle} is guaranteed by construction to equal
+   * {@code recharge + precharge(newEquipment) + initialCharge * newEquipment} for the
+   * FINAL newEquipment value, regardless of which (possibly stale) newEquipment
+   * estimate fed into sizing sales upstream. The stale estimate only affects how the
+   * population-growth target set by {@code recalcSales} is intended to be, not whether
+   * the final books balance.</p>
+   *
+   * <p>Setup: recharge 5% of priorEquipment with 1 kg/unit AND precharge 5% of
+   * newEquipment with 1 kg/unit (the circular case) with import tracked in kg (100 kg
+   * flat), then recover 50% with 100% reuse at the recharge stage (0% induction)
+   * starting in year 2023 - the year staleness would be most visible since the
+   * recharge base has already grown for two years by then.</p>
+   */
+  @Test
+  public void testPercentPrechargeSalesInvariantHoldsThroughRecover() throws IOException {
+    String qtaPath = "../examples/precharge_staleness_check.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    Stream<EngineResult> results = KigaliSimFacade.runScenario(program, "BAU", progress -> {});
+    List<EngineResult> resultsList = results.collect(Collectors.toList());
+
+    double priorEquipment = 0.0;
+    for (int year = 2021; year <= 2026; year++) {
+      EngineResult result = LiveTestsUtil.getResult(resultsList.stream(), year, "Test", "Sub");
+      assertNotNull(result, "Should have result for year " + year);
+
+      double domestic = result.getDomestic().getValue().doubleValue();
+      double importKg = result.getImport().getValue().doubleValue();
+      double recycle = result.getRecycle().getValue().doubleValue();
+      double salesTotal = domestic + importKg + recycle;
+
+      double newEquipment = result.getPopulationNew().getValue().doubleValue();
+      double expectedRecharge = 0.05 * priorEquipment;
+      double expectedPrecharge = 0.05 * newEquipment;
+      double expectedInitialCharge = 1.0 * newEquipment;
+      double expectedSalesTotal = expectedRecharge + expectedPrecharge + expectedInitialCharge;
+
+      assertEquals(expectedSalesTotal, salesTotal, 0.0001,
+          "domestic + import + recycle should equal recharge + precharge + initial charge "
+              + "for the actual newEquipment in year " + year);
+
+      priorEquipment = result.getPopulation().getValue().doubleValue();
+    }
+  }
+
+  /**
+   * Test precharge combined with a "cap" policy that reduces import sales.
+   *
+   * <p>Setup: BAU import = 105 kg flat, initial charge 1 kg/unit, precharge 5% of
+   * newEquipment with 1 kg/unit. The "Cap Import" policy caps import to 63 kg
+   * every year, which is below the BAU value so the cap is always binding.</p>
+   *
+   * <p>Cap is applied by directly setting the stream to the cap value and
+   * re-running the same population recalculation used by "set" (the circular
+   * percent-precharge case), so:</p>
+   *
+   * <pre>
+   * BAU newEquipment      = 105 / (1 + 0.05 * 1) = 100 units/year
+   * With Cap newEquipment =  63 / (1 + 0.05 * 1) =  60 units/year
+   * </pre>
+   *
+   * <p>Precharge emissions follow directly from newEquipment: precharge kg =
+   * newEquipment * 5% * 1 kg/unit, converted to tCO2e using 1430 kgCO2e / kg.</p>
+   */
+  @Test
+  public void testPrechargeWithCap() throws IOException {
+    String qtaPath = "../examples/precharge_with_cap.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    Stream<EngineResult> bauStream = KigaliSimFacade.runScenario(program, "BAU", progress -> {});
+    List<EngineResult> bauResults = bauStream.collect(Collectors.toList());
+
+    Stream<EngineResult> capStream = KigaliSimFacade.runScenario(program, "With Cap", progress -> {});
+    List<EngineResult> capResults = capStream.collect(Collectors.toList());
+
+    for (int year = 2021; year <= 2023; year++) {
+      EngineResult bauResult = LiveTestsUtil.getResult(
+          bauResults.stream(), year, "Domestic Refrigeration", "HFC-134a");
+      assertNotNull(bauResult, "Should have BAU result for year " + year);
+      assertEquals(100.0, bauResult.getPopulationNew().getValue().doubleValue(), 0.0001,
+          "BAU newEquipment should be 100 units in year " + year);
+      assertEquals(105.0, bauResult.getImport().getValue().doubleValue(), 0.0001,
+          "BAU import should be 105 kg in year " + year);
+
+      EngineResult capResult = LiveTestsUtil.getResult(
+          capResults.stream(), year, "Domestic Refrigeration", "HFC-134a");
+      assertNotNull(capResult, "Should have Cap result for year " + year);
+      assertEquals(60.0, capResult.getPopulationNew().getValue().doubleValue(), 0.0001,
+          "Capped newEquipment should be 60 units in year " + year
+              + " (63 kg / 1.05 kg-per-unit)");
+      assertEquals(63.0, capResult.getImport().getValue().doubleValue(), 0.0001,
+          "Capped import should be 63 kg in year " + year);
+
+      // Precharge kg = newEquipment * 5% * 1 kg/unit; emissions = precharge kg * 1430 kgCO2e/kg.
+      double expectedCapRechargeEmissionsTco2e = 60.0 * 0.05 * 1.0 * 1430.0 / 1000.0;
+      assertEquals(expectedCapRechargeEmissionsTco2e,
+          capResult.getRechargeEmissions().getValue().doubleValue(), 0.0001,
+          "Capped recharge (precharge) emissions should be " + expectedCapRechargeEmissionsTco2e
+              + " tCO2e in year " + year);
+    }
+
+    // Cap should strictly reduce cumulative population relative to BAU by year 2023.
+    EngineResult bauYear2023 = LiveTestsUtil.getResult(
+        bauResults.stream(), 2023, "Domestic Refrigeration", "HFC-134a");
+    EngineResult capYear2023 = LiveTestsUtil.getResult(
+        capResults.stream(), 2023, "Domestic Refrigeration", "HFC-134a");
+    assertNotNull(bauYear2023, "Should have BAU result for year 2023");
+    assertNotNull(capYear2023, "Should have Cap result for year 2023");
+    assertEquals(300.0, bauYear2023.getPopulation().getValue().doubleValue(), 0.0001,
+        "BAU population should be 300 units by year 2023");
+    assertEquals(180.0, capYear2023.getPopulation().getValue().doubleValue(), 0.0001,
+        "Capped population should be 180 units by year 2023");
+  }
+
+  /**
+   * Test precharge combined with a "floor" policy that raises import sales.
+   *
+   * <p>Setup: BAU import = 21 kg flat, initial charge 1 kg/unit, precharge 5% of
+   * newEquipment with 1 kg/unit. The "Floor Import" policy floors import to 73.5 kg
+   * every year, which is above the BAU value so the floor is always binding.</p>
+   *
+   * <pre>
+   * BAU newEquipment        = 21 / (1 + 0.05 * 1) = 20 units/year
+   * With Floor newEquipment = 73.5 / (1 + 0.05 * 1) = 70 units/year
+   * </pre>
+   */
+  @Test
+  public void testPrechargeWithFloor() throws IOException {
+    String qtaPath = "../examples/precharge_with_floor.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    Stream<EngineResult> bauStream = KigaliSimFacade.runScenario(program, "BAU", progress -> {});
+    List<EngineResult> bauResults = bauStream.collect(Collectors.toList());
+
+    Stream<EngineResult> floorStream = KigaliSimFacade.runScenario(program, "With Floor", progress -> {});
+    List<EngineResult> floorResults = floorStream.collect(Collectors.toList());
+
+    for (int year = 2021; year <= 2023; year++) {
+      EngineResult bauResult = LiveTestsUtil.getResult(
+          bauResults.stream(), year, "Domestic Refrigeration", "HFC-134a");
+      assertNotNull(bauResult, "Should have BAU result for year " + year);
+      assertEquals(20.0, bauResult.getPopulationNew().getValue().doubleValue(), 0.0001,
+          "BAU newEquipment should be 20 units in year " + year);
+      assertEquals(21.0, bauResult.getImport().getValue().doubleValue(), 0.0001,
+          "BAU import should be 21 kg in year " + year);
+
+      EngineResult floorResult = LiveTestsUtil.getResult(
+          floorResults.stream(), year, "Domestic Refrigeration", "HFC-134a");
+      assertNotNull(floorResult, "Should have Floor result for year " + year);
+      assertEquals(70.0, floorResult.getPopulationNew().getValue().doubleValue(), 0.0001,
+          "Floored newEquipment should be 70 units in year " + year
+              + " (73.5 kg / 1.05 kg-per-unit)");
+      assertEquals(73.5, floorResult.getImport().getValue().doubleValue(), 0.0001,
+          "Floored import should be 73.5 kg in year " + year);
+
+      // Precharge kg = newEquipment * 5% * 1 kg/unit; emissions = precharge kg * 1430 kgCO2e/kg.
+      double expectedFloorRechargeEmissionsTco2e = 70.0 * 0.05 * 1.0 * 1430.0 / 1000.0;
+      assertEquals(expectedFloorRechargeEmissionsTco2e,
+          floorResult.getRechargeEmissions().getValue().doubleValue(), 0.0001,
+          "Floored recharge (precharge) emissions should be " + expectedFloorRechargeEmissionsTco2e
+              + " tCO2e in year " + year);
+    }
+
+    // Floor should strictly increase cumulative population relative to BAU by year 2023.
+    EngineResult bauYear2023 = LiveTestsUtil.getResult(
+        bauResults.stream(), 2023, "Domestic Refrigeration", "HFC-134a");
+    EngineResult floorYear2023 = LiveTestsUtil.getResult(
+        floorResults.stream(), 2023, "Domestic Refrigeration", "HFC-134a");
+    assertNotNull(bauYear2023, "Should have BAU result for year 2023");
+    assertNotNull(floorYear2023, "Should have Floor result for year 2023");
+    assertEquals(60.0, bauYear2023.getPopulation().getValue().doubleValue(), 0.0001,
+        "BAU population should be 60 units by year 2023");
+    assertEquals(210.0, floorYear2023.getPopulation().getValue().doubleValue(), 0.0001,
+        "Floored population should be 210 units by year 2023");
   }
 
   /**

--- a/examples/precharge_staleness_check.qta
+++ b/examples/precharge_staleness_check.qta
@@ -1,0 +1,27 @@
+start default
+
+  define application "Test"
+
+    uses substance "Sub"
+      enable import
+      initial charge with 0 kg / unit for domestic
+      initial charge with 1 kg / unit for import
+      initial charge with 0 kg / unit for export
+      equals 1430 kgCO2e / kg
+      equals 1 kwh / unit
+      set import to 100 kg during year 2021
+      recharge 5 % of priorEquipment with 1 kg / unit
+      recharge 5 % of newEquipment with 1 kg / unit
+      recover 50 % with 100 % reuse with 0 % induction at recharge during years 2023 to onwards
+    end substance
+
+  end application
+
+end default
+
+start simulations
+
+  simulate "BAU"
+  from years 2021 to 2026
+
+end simulations

--- a/examples/precharge_with_cap.qta
+++ b/examples/precharge_with_cap.qta
@@ -1,0 +1,42 @@
+start default
+
+  define application "Domestic Refrigeration"
+
+    uses substance "HFC-134a"
+      enable import
+      initial charge with 0 kg / unit for domestic
+      initial charge with 1 kg / unit for import
+      initial charge with 0 kg / unit for export
+      equals 1430 kgCO2e / kg
+      equals 1 kwh / unit
+      set import to 105 kg during year 2021
+      recharge 5 % of newEquipment with 1 kg / unit
+    end substance
+
+  end application
+
+end default
+
+start policy "Cap Import"
+
+  modify application "Domestic Refrigeration"
+
+    modify substance "HFC-134a"
+      cap import to 63 kg
+    end substance
+
+  end application
+
+end policy
+
+
+start simulations
+
+  simulate "BAU"
+  from years 2021 to 2023
+
+  simulate "With Cap"
+    using "Cap Import"
+  from years 2021 to 2023
+
+end simulations

--- a/examples/precharge_with_floor.qta
+++ b/examples/precharge_with_floor.qta
@@ -1,0 +1,42 @@
+start default
+
+  define application "Domestic Refrigeration"
+
+    uses substance "HFC-134a"
+      enable import
+      initial charge with 0 kg / unit for domestic
+      initial charge with 1 kg / unit for import
+      initial charge with 0 kg / unit for export
+      equals 1430 kgCO2e / kg
+      equals 1 kwh / unit
+      set import to 21 kg during year 2021
+      recharge 5 % of newEquipment with 1 kg / unit
+    end substance
+
+  end application
+
+end default
+
+start policy "Floor Import"
+
+  modify application "Domestic Refrigeration"
+
+    modify substance "HFC-134a"
+      floor import to 73.5 kg
+    end substance
+
+  end application
+
+end policy
+
+
+start simulations
+
+  simulate "BAU"
+  from years 2021 to 2023
+
+  simulate "With Floor"
+    using "Floor Import"
+  from years 2021 to 2023
+
+end simulations

--- a/examples/precharge_with_recover.qta
+++ b/examples/precharge_with_recover.qta
@@ -1,0 +1,27 @@
+start default
+
+  define application "Domestic Refrigeration"
+
+    uses substance "HFC-134a"
+      enable import
+      initial charge with 0 kg / unit for domestic
+      initial charge with 1 kg / unit for import
+      initial charge with 0 kg / unit for export
+      equals 1430 kgCO2e / kg
+      equals 1 kwh / unit
+      set import to 105 kg during year 2021
+      recharge 5 % of newEquipment with 1 kg / unit
+      recover 20 kg with 100 % reuse with 0 % induction during years 2021 to onwards
+    end substance
+
+  end application
+
+end default
+
+
+start simulations
+
+  simulate "BAU"
+  from years 2021 to 2023
+
+end simulations

--- a/examples/recharge_of_invalid_target.qta
+++ b/examples/recharge_of_invalid_target.qta
@@ -1,0 +1,22 @@
+start default
+
+  define application "test"
+
+    uses substance "test"
+      enable domestic
+      set domestic to 100 mt
+      initial charge with 1 kg / unit for domestic
+      recharge 10 % of bank with 1 kg / unit
+      equals 5 tCO2e / mt
+    end substance
+
+  end application
+
+end default
+
+
+start simulations
+
+  simulate "business as usual" from years 1 to 2
+
+end simulations


### PR DESCRIPTION
Various minor edits including

- Restrict the recharge "of" clause grammar to priorEquipment/newEquipment only (was accepting any stream, e.g. "of bank", silently treated as recharge)
- Add precharge tests for recover, cap, and floor per issue #807's procedure, plus a 100% precharge case and a regression test pinning the sales/recharge/ precharge bookkeeping invariant through recovery
- Strengthen two weak `> 0` assertions in PrechargeLiveTests to exact hand-derived values
- Add fail-fast field validation to ServicingOffsetBuilder and DemandAnalysisBuilder so a missing setter throws a clear IllegalStateException instead of an NPE deep in calculation logic
- Document the intentional recharge/precharge asymmetry in getSalesPersistThroughRecharge
- Remove a dead local variable in SalesRecalcStrategy and trim a redundant glossary sentence