### PR TITLE
Generalize ValidatedBuilder and migrate six builders onto it

### DIFF
--- a/engine/src/main/java/org/kigalisim/engine/recalc/RecalcKitBuilder.java
+++ b/engine/src/main/java/org/kigalisim/engine/recalc/RecalcKitBuilder.java
@@ -13,11 +13,12 @@ import java.util.Optional;
 import org.kigalisim.engine.number.UnitConverter;
 import org.kigalisim.engine.state.SimulationState;
 import org.kigalisim.engine.state.StateGetter;
+import org.kigalisim.engine.support.ValidatedBuilder;
 
 /**
  * Builder for creating RecalcKit instances.
  */
-public class RecalcKitBuilder {
+public class RecalcKitBuilder extends ValidatedBuilder<RecalcKit> {
 
   private Optional<SimulationState> simulationState;
   private Optional<UnitConverter> unitConverter;
@@ -27,6 +28,7 @@ public class RecalcKitBuilder {
    * Create a new RecalcKitBuilder.
    */
   public RecalcKitBuilder() {
+    super("RecalcKit");
     this.simulationState = Optional.empty();
     this.unitConverter = Optional.empty();
     this.stateGetter = Optional.empty();
@@ -69,18 +71,21 @@ public class RecalcKitBuilder {
    * Build the RecalcKit.
    *
    * @return A new RecalcKit instance
+   */
+  @Override
+  protected RecalcKit buildInternal() {
+    return new RecalcKit(simulationState.get(), unitConverter.get(), stateGetter.get());
+  }
+
+  /**
+   * Check that all required fields are set before construction.
+   *
    * @throws IllegalStateException if any required field is missing
    */
-  public RecalcKit build() {
-    if (simulationState.isEmpty()) {
-      throw new IllegalStateException("SimulationState is required");
-    }
-    if (unitConverter.isEmpty()) {
-      throw new IllegalStateException("UnitConverter is required");
-    }
-    if (stateGetter.isEmpty()) {
-      throw new IllegalStateException("StateGetter is required");
-    }
-    return new RecalcKit(simulationState.get(), unitConverter.get(), stateGetter.get());
+  @Override
+  protected void validate() {
+    requireField(simulationState, "simulationState");
+    requireField(unitConverter, "unitConverter");
+    requireField(stateGetter, "stateGetter");
   }
 }

--- a/engine/src/main/java/org/kigalisim/engine/recalc/SalesStreamDistributionBuilder.java
+++ b/engine/src/main/java/org/kigalisim/engine/recalc/SalesStreamDistributionBuilder.java
@@ -14,6 +14,7 @@ import java.math.BigDecimal;
 import java.math.MathContext;
 import java.util.Optional;
 import org.kigalisim.engine.number.EngineNumber;
+import org.kigalisim.engine.support.ValidatedBuilder;
 
 /**
  * Builder for creating sales stream distribution percentages.
@@ -22,7 +23,7 @@ import org.kigalisim.engine.number.EngineNumber;
  * split between import, domestic, and export based on which streams have been explicitly enabled
  * and their current values.</p>
  */
-public class SalesStreamDistributionBuilder {
+public class SalesStreamDistributionBuilder extends ValidatedBuilder<SalesStreamDistribution> {
 
   private Optional<EngineNumber> domesticSales;
   private Optional<EngineNumber> importSales;
@@ -36,6 +37,7 @@ public class SalesStreamDistributionBuilder {
    * Create builder without any values initialized.
    */
   public SalesStreamDistributionBuilder() {
+    super("SalesStreamDistribution");
     domesticSales = Optional.empty();
     importSales = Optional.empty();
     exportSales = Optional.empty();
@@ -134,11 +136,9 @@ public class SalesStreamDistributionBuilder {
    * </ul></div>
    *
    * @return A SalesStreamDistribution with appropriate percentages
-   * @throws IllegalStateException if any required field is missing
    */
-  public SalesStreamDistribution build() {
-    checkReadyToConstruct();
-
+  @Override
+  protected SalesStreamDistribution buildInternal() {
     BigDecimal domesticSalesKg = domesticSales.get().getValue();
     BigDecimal importSalesKg = importSales.get().getValue();
     BigDecimal exportSalesKg = exportSales.get().getValue();
@@ -219,28 +219,15 @@ public class SalesStreamDistributionBuilder {
    *
    * @throws IllegalStateException if any required field is missing
    */
-  private void checkReadyToConstruct() {
-    checkValid(domesticSales, "domesticSales");
-    checkValid(importSales, "importSales");
-    checkValid(exportSales, "exportSales");
-    checkValid(domesticEnabled, "domesticEnabled");
-    checkValid(importEnabled, "importEnabled");
-    checkValid(exportEnabled, "exportEnabled");
-    checkValid(includeExports, "includeExports");
-  }
-
-  /**
-   * Check if a value is valid (not empty).
-   *
-   * @param value The optional value to check
-   * @param name The name of the field for error reporting
-   * @throws IllegalStateException if the value is empty
-   */
-  private void checkValid(Optional<?> value, String name) {
-    if (value.isEmpty()) {
-      throw new IllegalStateException(
-          "Could not make sales stream distribution because " + name + " was not given.");
-    }
+  @Override
+  protected void validate() {
+    requireField(domesticSales, "domesticSales");
+    requireField(importSales, "importSales");
+    requireField(exportSales, "exportSales");
+    requireField(domesticEnabled, "domesticEnabled");
+    requireField(importEnabled, "importEnabled");
+    requireField(exportEnabled, "exportEnabled");
+    requireField(includeExports, "includeExports");
   }
 
 }

--- a/engine/src/main/java/org/kigalisim/engine/recalc/StreamUpdateBuilder.java
+++ b/engine/src/main/java/org/kigalisim/engine/recalc/StreamUpdateBuilder.java
@@ -5,6 +5,7 @@ import org.kigalisim.engine.number.EngineNumber;
 import org.kigalisim.engine.state.UseKey;
 import org.kigalisim.engine.state.YearMatcher;
 import org.kigalisim.engine.support.EngineSupportUtils;
+import org.kigalisim.engine.support.ValidatedBuilder;
 
 /**
  * Builder for creating StreamUpdate instances.
@@ -12,7 +13,7 @@ import org.kigalisim.engine.support.EngineSupportUtils;
  * <p>Provides a fluent interface for constructing StreamUpdate objects with optional
  * parameters and validation.</p>
  */
-public final class StreamUpdateBuilder {
+public final class StreamUpdateBuilder extends ValidatedBuilder<StreamUpdate> {
   private String name;
   private EngineNumber value;
   private Optional<YearMatcher> yearMatcher = Optional.empty();
@@ -27,6 +28,7 @@ public final class StreamUpdateBuilder {
    * Creates a new StreamUpdateBuilder with default values.
    */
   public StreamUpdateBuilder() {
+    super("StreamUpdate");
     this.distribution = Optional.empty();
   }
 
@@ -177,15 +179,23 @@ public final class StreamUpdateBuilder {
   }
 
   /**
+   * Check that all required fields are set before construction.
+   *
+   * @throws IllegalStateException if name or value is not set
+   */
+  @Override
+  protected void validate() {
+    requireField(name, "name");
+    requireField(value, "value");
+  }
+
+  /**
    * Builds the StreamUpdate.
    *
    * @return the built StreamUpdate
-   * @throws IllegalStateException if name or value is not set
    */
-  public StreamUpdate build() {
-    if (name == null || value == null) {
-      throw new IllegalStateException("Name and value are required");
-    }
+  @Override
+  protected StreamUpdate buildInternal() {
     return new StreamUpdate(
         name,
         value,

--- a/engine/src/main/java/org/kigalisim/engine/recalc/util/DemandAnalysisBuilder.java
+++ b/engine/src/main/java/org/kigalisim/engine/recalc/util/DemandAnalysisBuilder.java
@@ -18,6 +18,7 @@ import org.kigalisim.engine.number.EngineNumber;
 import org.kigalisim.engine.state.SimulationState;
 import org.kigalisim.engine.state.UseKey;
 import org.kigalisim.engine.support.EngineSupportUtils;
+import org.kigalisim.engine.support.ValidatedBuilder;
 import org.kigalisim.lang.operation.RecoverOperation.RecoveryStage;
 
 /**

--- a/engine/src/main/java/org/kigalisim/engine/recalc/util/ServicingOffsetBuilder.java
+++ b/engine/src/main/java/org/kigalisim/engine/recalc/util/ServicingOffsetBuilder.java
@@ -19,6 +19,7 @@ import org.kigalisim.engine.number.UnitConverter;
 import org.kigalisim.engine.state.OverridingConverterStateGetter;
 import org.kigalisim.engine.state.StateGetter;
 import org.kigalisim.engine.support.DivisionHelper;
+import org.kigalisim.engine.support.ValidatedBuilder;
 
 /**
  * Builder that calculates servicing (precharge/recharge) offsets for population changes.

--- a/engine/src/main/java/org/kigalisim/engine/serializer/EngineResultBuilder.java
+++ b/engine/src/main/java/org/kigalisim/engine/serializer/EngineResultBuilder.java
@@ -11,6 +11,7 @@ package org.kigalisim.engine.serializer;
 
 import java.util.Optional;
 import org.kigalisim.engine.number.EngineNumber;
+import org.kigalisim.engine.support.ValidatedBuilder;
 
 /**
  * Builder pattern implementation for creating EngineResult objects.
@@ -18,7 +19,7 @@ import org.kigalisim.engine.number.EngineNumber;
  * <p>This builder ensures that all required fields are provided before
  * constructing an EngineResult instance.</p>
  */
-public class EngineResultBuilder {
+public class EngineResultBuilder extends ValidatedBuilder<EngineResult> {
   private Optional<String> application;
   private Optional<String> substance;
   private Optional<Integer> year;
@@ -48,6 +49,7 @@ public class EngineResultBuilder {
    * Create builder without any values initialized.
    */
   public EngineResultBuilder() {
+    super("EngineResult");
     application = Optional.empty();
     substance = Optional.empty();
     year = Optional.empty();
@@ -560,13 +562,12 @@ public class EngineResultBuilder {
   }
 
   /**
-   * Check that the builder is complete and create a new result.
+   * Create a new result from the values provided to this builder.
    *
    * @return The result built from the values provided to this builder
-   * @throws IllegalStateException if any required field is missing
    */
-  public EngineResult build() {
-    checkReadyToConstruct();
+  @Override
+  protected EngineResult buildInternal() {
     return new EngineResult(this);
   }
 
@@ -575,44 +576,31 @@ public class EngineResultBuilder {
    *
    * @throws IllegalStateException if any required field is missing
    */
-  private void checkReadyToConstruct() {
-    checkValid(application, "application");
-    checkValid(substance, "substance");
-    checkValid(year, "year");
-    checkValid(scenarioName, "scenarioName");
-    checkValid(trialNumber, "trialNumber");
-    checkValid(domesticValue, "domesticValue");
-    checkValid(importValue, "importValue");
-    checkValid(recycleValue, "recycleValue");
-    checkValid(domesticConsumptionValue, "domesticConsumptionValue");
-    checkValid(importConsumptionValue, "importConsumptionValue");
-    checkValid(recycleConsumptionValue, "recycleConsumptionValue");
-    checkValid(populationValue, "populationValue");
-    checkValid(populationNew, "populationNew");
-    checkValid(rechargeEmissions, "rechargeEmissions");
-    checkValid(eolEmissions, "eolEmissions");
-    checkValid(initialChargeEmissions, "initialChargeEmissions");
-    checkValid(energyConsumption, "energyConsumption");
-    checkValid(exportValue, "exportValue");
-    checkValid(exportConsumptionValue, "exportConsumptionValue");
-    checkValid(tradeSupplement, "tradeSupplement");
-    checkValid(bankKg, "bankKg");
-    checkValid(bankTco2e, "bankTco2e");
-    checkValid(bankChangeKg, "bankChangeKg");
-    checkValid(bankChangeTco2e, "bankChangeTco2e");
-  }
-
-  /**
-   * Check if a value is valid (not empty).
-   *
-   * @param value The optional value to check
-   * @param name The name of the field for error reporting
-   * @throws IllegalStateException if the value is empty
-   */
-  private void checkValid(Optional<?> value, String name) {
-    if (value.isEmpty()) {
-      throw new IllegalStateException(
-          "Could not make engine result because " + name + " was not given.");
-    }
+  @Override
+  protected void validate() {
+    requireField(application, "application");
+    requireField(substance, "substance");
+    requireField(year, "year");
+    requireField(scenarioName, "scenarioName");
+    requireField(trialNumber, "trialNumber");
+    requireField(domesticValue, "domesticValue");
+    requireField(importValue, "importValue");
+    requireField(recycleValue, "recycleValue");
+    requireField(domesticConsumptionValue, "domesticConsumptionValue");
+    requireField(importConsumptionValue, "importConsumptionValue");
+    requireField(recycleConsumptionValue, "recycleConsumptionValue");
+    requireField(populationValue, "populationValue");
+    requireField(populationNew, "populationNew");
+    requireField(rechargeEmissions, "rechargeEmissions");
+    requireField(eolEmissions, "eolEmissions");
+    requireField(initialChargeEmissions, "initialChargeEmissions");
+    requireField(energyConsumption, "energyConsumption");
+    requireField(exportValue, "exportValue");
+    requireField(exportConsumptionValue, "exportConsumptionValue");
+    requireField(tradeSupplement, "tradeSupplement");
+    requireField(bankKg, "bankKg");
+    requireField(bankTco2e, "bankTco2e");
+    requireField(bankChangeKg, "bankChangeKg");
+    requireField(bankChangeTco2e, "bankChangeTco2e");
   }
 }

--- a/engine/src/main/java/org/kigalisim/engine/state/SimulationStateUpdateBuilder.java
+++ b/engine/src/main/java/org/kigalisim/engine/state/SimulationStateUpdateBuilder.java
@@ -3,6 +3,7 @@ package org.kigalisim.engine.state;
 import java.util.Optional;
 import org.kigalisim.engine.number.EngineNumber;
 import org.kigalisim.engine.recalc.SalesStreamDistribution;
+import org.kigalisim.engine.support.ValidatedBuilder;
 
 /**
  * Builder for creating SimulationStateUpdate instances.
@@ -10,7 +11,7 @@ import org.kigalisim.engine.recalc.SalesStreamDistribution;
  * <p>Provides a fluent interface for constructing SimulationStateUpdate objects
  * with validation and sensible defaults.</p>
  */
-public final class SimulationStateUpdateBuilder {
+public final class SimulationStateUpdateBuilder extends ValidatedBuilder<SimulationStateUpdate> {
   private UseKey useKey;
   private String name;
   private EngineNumber value;
@@ -22,6 +23,7 @@ public final class SimulationStateUpdateBuilder {
    * Creates a new SimulationStateUpdateBuilder with default values.
    */
   public SimulationStateUpdateBuilder() {
+    super("SimulationStateUpdate");
     // Default values are set in field declarations
   }
 
@@ -120,22 +122,24 @@ public final class SimulationStateUpdateBuilder {
   }
 
   /**
+   * Check that all required fields are set before construction.
+   *
+   * @throws IllegalStateException if required fields are not set
+   */
+  @Override
+  protected void validate() {
+    requireField(useKey, "useKey");
+    requireField(name, "name");
+    requireField(value, "value");
+  }
+
+  /**
    * Builds the SimulationStateUpdate.
    *
    * @return the built SimulationStateUpdate
-   * @throws IllegalStateException if required fields are not set
    */
-  public SimulationStateUpdate build() {
-    if (useKey == null) {
-      throw new IllegalStateException("UseKey is required");
-    }
-    if (name == null) {
-      throw new IllegalStateException("Name is required");
-    }
-    if (value == null) {
-      throw new IllegalStateException("Value is required");
-    }
-
+  @Override
+  protected SimulationStateUpdate buildInternal() {
     return new SimulationStateUpdate(
         useKey,
         name,

--- a/engine/src/main/java/org/kigalisim/engine/support/ChangeExecutorConfigBuilder.java
+++ b/engine/src/main/java/org/kigalisim/engine/support/ChangeExecutorConfigBuilder.java
@@ -17,7 +17,7 @@ import org.kigalisim.engine.state.YearMatcher;
 /**
  * Builder for creating ChangeExecutorConfig instances with fluent interface.
  */
-public final class ChangeExecutorConfigBuilder {
+public final class ChangeExecutorConfigBuilder extends ValidatedBuilder<ChangeExecutorConfig> {
 
   private Optional<String> stream;
   private Optional<EngineNumber> amount;
@@ -28,6 +28,7 @@ public final class ChangeExecutorConfigBuilder {
    * Create a new ChangeExecutorConfigBuilder.
    */
   public ChangeExecutorConfigBuilder() {
+    super("ChangeExecutorConfig");
     this.stream = Optional.empty();
     this.amount = Optional.empty();
     this.yearMatcher = Optional.empty();
@@ -79,22 +80,24 @@ public final class ChangeExecutorConfigBuilder {
   }
 
   /**
+   * Check that all required fields are set before construction.
+   *
+   * @throws IllegalStateException if required fields are not set
+   */
+  @Override
+  protected void validate() {
+    requireField(stream, "stream");
+    requireField(amount, "amount");
+    requireField(useKeyEffective, "useKeyEffective");
+  }
+
+  /**
    * Builds the ChangeExecutorConfig.
    *
    * @return the built ChangeExecutorConfig
-   * @throws IllegalStateException if required fields are not set
    */
-  public ChangeExecutorConfig build() {
-    if (stream.isEmpty()) {
-      throw new IllegalStateException("Stream is required");
-    }
-    if (amount.isEmpty()) {
-      throw new IllegalStateException("Amount is required");
-    }
-    if (useKeyEffective.isEmpty()) {
-      throw new IllegalStateException("UseKeyEffective is required");
-    }
-
+  @Override
+  protected ChangeExecutorConfig buildInternal() {
     return new ChangeExecutorConfig(
         stream.get(),
         amount.get(),

--- a/engine/src/main/java/org/kigalisim/engine/support/ValidatedBuilder.java
+++ b/engine/src/main/java/org/kigalisim/engine/support/ValidatedBuilder.java
@@ -4,7 +4,7 @@
  * @license BSD-3-Clause
  */
 
-package org.kigalisim.engine.recalc.util;
+package org.kigalisim.engine.support;
 
 import java.util.Optional;
 
@@ -67,6 +67,19 @@ public abstract class ValidatedBuilder<T> {
    */
   protected void requireField(Object value, String fieldName) {
     if (Optional.ofNullable(value).isEmpty()) {
+      throw new IllegalStateException(fieldName + " is required to build a " + builtTypeName);
+    }
+  }
+
+  /**
+   * Require that a builder field backed by an {@link Optional} was set before building.
+   *
+   * @param value The optional field value to check
+   * @param fieldName The name of the field, used in the error message
+   * @throws IllegalStateException if value is empty
+   */
+  protected void requireField(Optional<?> value, String fieldName) {
+    if (value.isEmpty()) {
       throw new IllegalStateException(fieldName + " is required to build a " + builtTypeName);
     }
   }

--- a/engine/src/test/java/org/kigalisim/engine/support/ChangeExecutorConfigBuilderTest.java
+++ b/engine/src/test/java/org/kigalisim/engine/support/ChangeExecutorConfigBuilderTest.java
@@ -90,7 +90,7 @@ class ChangeExecutorConfigBuilderTest {
         IllegalStateException.class,
         () -> builder.build()
     );
-    assertEquals("Stream is required", exception.getMessage());
+    assertEquals("stream is required to build a ChangeExecutorConfig", exception.getMessage());
   }
 
   @Test
@@ -103,7 +103,7 @@ class ChangeExecutorConfigBuilderTest {
         IllegalStateException.class,
         () -> builder.build()
     );
-    assertEquals("Amount is required", exception.getMessage());
+    assertEquals("amount is required to build a ChangeExecutorConfig", exception.getMessage());
   }
 
   @Test
@@ -116,7 +116,8 @@ class ChangeExecutorConfigBuilderTest {
         IllegalStateException.class,
         () -> builder.build()
     );
-    assertEquals("UseKeyEffective is required", exception.getMessage());
+    assertEquals("useKeyEffective is required to build a ChangeExecutorConfig",
+        exception.getMessage());
   }
 
   @Test


### PR DESCRIPTION
Move ValidatedBuilder from engine.recalc.util to engine.support (its general-purpose home) and add a requireField(Optional<?>, String) overload for builders that keep fields as Optional<T> internally.

Migrate EngineResultBuilder, SalesStreamDistributionBuilder, RecalcKitBuilder, StreamUpdateBuilder, ChangeExecutorConfigBuilder, and SimulationStateUpdateBuilder onto it, replacing hand-rolled required-field checks with the shared validate()/requireField() pattern. Two builders were left alone as poor fits: RecalcOperationBuilder validates call sequencing rather than missing fields, and ImplicitRechargeUpdateBuilder has two separate build-like exit points instead of a single build().

Updated ChangeExecutorConfigBuilderTest's three exact-message assertions to match the new standardized error format.