### PR TITLE
Bump version to 0.2.0 and update beta changelog

### DIFF
--- a/beta_changelog.md
+++ b/beta_changelog.md
@@ -14,9 +14,17 @@ Finally, we want to again express our gratitude for your feedback and time.
 
 The following changes have been adopted and released.
 
+### Recharge of new equipment (precharge)
+
+**Status**: Released July 24, 2026
+
+**Classification**: Enhancement
+
+Added an optional `of` clause to the `recharge` command, allowing users to specify whether servicing applies to `priorEquipment` (the existing default) or `newEquipment`. When `of newEquipment` is specified, the recharge applies to new equipment prior to going into service. For example, this could account for substance lost in transit or storage before sale. Previously, this use case could only be approximated with manual calculations (e.g., `recharge 3 % of newEquipment with 1 kg / unit`). This formalized behavior now handles the recalculation logic across `recover`, `set`, `change`, `cap`, and `floor` operations automatically, including the circular case for volume-based sales with percentage-based precharge. The feature surfaces in the UI-based editor as a dropdown (defaulting to `priorEquipment`) in the servicing configuration. See [#807](https://github.com/SchmidtDSE/kigali-sim/issues/807), [#808](https://github.com/SchmidtDSE/kigali-sim/pull/808).
+
 ### Time-varying equals
 
-**Status**: Released July 21, 2026
+**Status**: Released July 24, 2026
 
 **Classification**: Enhancement
 

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = 'org.kigalisim'
-version = '0.1.9'
+version = '0.2.0'
 
 eclipse {
     classpath {
@@ -272,7 +272,7 @@ publishing {
       gpr(MavenPublication) {
         groupId = 'org.kigalisim'
         artifactId = 'engine'
-        version = '0.1.9'
+        version = '0.2.0'
 
         from(components.java)
         artifact fatJarVersion


### PR DESCRIPTION
- Bump version from 0.1.9 to 0.2.0 in engine/build.gradle
- Update Time-varying equals release date to July 24, 2026
- Add precharge (recharge of newEquipment) entry to beta changelog