### PR TITLE
Fix a bug from #822 where the dialog is empty when reading get at.

### DIFF
--- a/editor/js/ace-mode-qubectalk.js
+++ b/editor/js/ace-mode-qubectalk.js
@@ -11,7 +11,7 @@ ace.define("ace/mode/qubectalk", [
     const structureKeywords = "about|application|default|define|end|policy|simulations|start|" +
       "substance|uses|variables";
 
-    const commandKeywords = "across|as|assume|at|by|cap|change|charge|current|" +
+    const commandKeywords = "across|ago|as|assume|at|by|cap|change|charge|current|" +
       "continued|during|enable|eol|floor|for|from|get|in|induction|initial|" +
       "modify|no|of|only|prior|recharge|recover|replace|replacement|retire|reuse|" +
       "set|simulate|then|to|trials|using|volume|with";

--- a/editor/js/ui_translator.js
+++ b/editor/js/ui_translator.js
@@ -358,6 +358,61 @@ class TranslatorVisitor extends toolkit.QubecTalkVisitor {
   }
 
   /**
+   * Visit a years-ago stream access expression node.
+   *
+   * @param {Object} ctx - The parse tree node context.
+   * @returns {string} The years-ago stream access text.
+   */
+  visitGetStreamPrior(ctx) {
+    const self = this;
+    const yearsAgo = ctx.getChild(2).getText();
+    return "get " + ctx.getChild(1).getText() + " " + yearsAgo + " years ago";
+  }
+
+  /**
+   * Visit a years-ago stream conversion expression node.
+   *
+   * @param {Object} ctx - The parse tree node context.
+   * @returns {string} The years-ago stream conversion text.
+   */
+  visitGetStreamPriorConversion(ctx) {
+    const self = this;
+    const yearsAgo = ctx.getChild(2).getText();
+    const part1 = "get " + ctx.getChild(1).getText() + " " + yearsAgo + " years ago";
+    const part2 = " as " + ctx.getChild(6).getText();
+    return part1 + part2;
+  }
+
+  /**
+   * Visit an indirect years-ago stream access expression node.
+   *
+   * @param {Object} ctx - The parse tree node context.
+   * @returns {string} The indirect years-ago stream access text.
+   */
+  visitGetStreamIndirectPrior(ctx) {
+    const self = this;
+    const yearsAgo = ctx.getChild(2).getText();
+    const part1 = "get " + ctx.getChild(1).getText() + " " + yearsAgo + " years ago";
+    const part2 = " of " + ctx.getChild(6).getText();
+    return part1 + part2;
+  }
+
+  /**
+   * Visit an indirect years-ago stream conversion expression node.
+   *
+   * @param {Object} ctx - The parse tree node context.
+   * @returns {string} The indirect years-ago stream conversion text.
+   */
+  visitGetStreamIndirectPriorConversion(ctx) {
+    const self = this;
+    const yearsAgo = ctx.getChild(2).getText();
+    const part1 = "get " + ctx.getChild(1).getText() + " " + yearsAgo + " years ago";
+    const part2 = " of " + ctx.getChild(6).getText();
+    const part3 = " as " + ctx.getChild(8).getText();
+    return part1 + part2 + part3;
+  }
+
+  /**
    * Visit a minimum limit expression node.
    *
    * @param {Object} ctx - The parse tree node context.

--- a/editor/test/test_ui_translator.js
+++ b/editor/test/test_ui_translator.js
@@ -745,6 +745,81 @@ function buildUiTranslatorTests() {
       },
     ]);
 
+    QUnit.test("translates retire command with years-ago formula", function (assert) {
+      const code = `
+start default
+  define application "test"
+    uses substance "test"
+      enable domestic
+      equals 1 tCO2e / mt
+      initial charge with 1 kg / unit for domestic
+      set domestic to 100 mt during year 1
+      retire (get sales 5 years ago as %) * 10 % / year
+    end substance
+  end application
+end default
+`;
+
+      const compiler = new UiTranslatorCompiler();
+      const result = compiler.compile(code);
+      assert.strictEqual(result.getErrors().length, 0, "Should compile without errors");
+
+      const program = result.getProgram();
+      const substance = program.getApplications()[0].getSubstances()[0];
+
+      const retire = substance.getRetire();
+      assert.ok(retire !== null, "Retire command should be present");
+
+      const retireValue = retire.getValue();
+      assert.equal(retireValue.getUnits(), "% / year");
+
+      const rawValue = retireValue.getValue();
+      assert.ok(
+        typeof rawValue === "string" && rawValue.includes("years ago"),
+        "Years-ago formula text should be preserved, not blanked out",
+      );
+    });
+
+    QUnit.test("translates retire command with indirect years-ago conversion formula", function (assert) {
+      const code = `
+start default
+  define application "test"
+    uses substance "other"
+      enable domestic
+      equals 1 tCO2e / mt
+      initial charge with 1 kg / unit for domestic
+      set domestic to 100 mt during year 1
+    end substance
+
+    uses substance "test"
+      enable domestic
+      equals 1 tCO2e / mt
+      initial charge with 1 kg / unit for domestic
+      set domestic to 100 mt during year 1
+      retire (get sales 5 years ago of "other" as %) * 10 % / year
+    end substance
+  end application
+end default
+`;
+
+      const compiler = new UiTranslatorCompiler();
+      const result = compiler.compile(code);
+      assert.strictEqual(result.getErrors().length, 0, "Should compile without errors");
+
+      const program = result.getProgram();
+      const application = program.getApplications()[0];
+      const substance = application.getSubstances().find((x) => x.getName() === "test");
+
+      const retire = substance.getRetire();
+      const rawValue = retire.getValue().getValue();
+      assert.ok(
+        typeof rawValue === "string" &&
+          rawValue.includes("years ago") &&
+          rawValue.includes('of "other"'),
+        "Indirect years-ago formula text should be preserved with substance reference",
+      );
+    });
+
     QUnit.test("preprocessEachYearSyntax - removes end-of-line each year", function (assert) {
       // Test basic removal cases
       const input1 = "retire 5 % each year";


### PR DESCRIPTION
Fix a bug from #822 (not yet released to production) where the substance edit dialog is empty when reading a get at statement. This fills in the JS visitor.