### PR TITLE
Have naked percent cap refer to stream not population

### DIFF
--- a/engine/src/main/java/org/kigalisim/engine/support/LimitExecutor.java
+++ b/engine/src/main/java/org/kigalisim/engine/support/LimitExecutor.java
@@ -434,8 +434,11 @@ public class LimitExecutor {
     boolean hasPrior = lastSpecified != null;
 
     if (hasPrior) {
-      EngineNumber percentPriorYear = new EngineNumber(amount.getValue(), "% prior year");
-      EngineNumber newFloorValue = unitConverter.convert(percentPriorYear, lastSpecified.getUnits());
+      BigDecimal factor = amount.getValue().divide(BigDecimal.valueOf(100));
+      EngineNumber newFloorValue = new EngineNumber(
+          lastSpecified.getValue().multiply(factor),
+          lastSpecified.getUnits()
+      );
 
       EngineNumber currentInKg = unitConverter.convert(currentValueRaw, "kg");
       EngineNumber newFloorInKg = unitConverter.convert(newFloorValue, "kg");

--- a/engine/src/main/java/org/kigalisim/engine/support/LimitExecutor.java
+++ b/engine/src/main/java/org/kigalisim/engine/support/LimitExecutor.java
@@ -288,12 +288,11 @@ public class LimitExecutor {
     if (hasPrior) {
       EngineNumber newCappedValue;
       if (lastSpecified.hasEquipmentUnits()) {
-        // The last-specified value is in equipment units. Applying a percent here must scale the
-        // user-specified unit count (e.g. 90% of 1000 units = 900 units), NOT convert the percent
-        // against the population base, which would make the cap enormous and non-binding.
         BigDecimal factor = amount.getValue().divide(BigDecimal.valueOf(100));
         newCappedValue = new EngineNumber(
-            lastSpecified.getValue().multiply(factor), lastSpecified.getUnits());
+            lastSpecified.getValue().multiply(factor),
+            lastSpecified.getUnits()
+        );
       } else {
         EngineNumber percentPriorYear = new EngineNumber(amount.getValue(), "% prior year");
         newCappedValue = unitConverter.convert(percentPriorYear, lastSpecified.getUnits());

--- a/engine/src/main/java/org/kigalisim/engine/support/LimitExecutor.java
+++ b/engine/src/main/java/org/kigalisim/engine/support/LimitExecutor.java
@@ -286,17 +286,11 @@ public class LimitExecutor {
     boolean hasPrior = lastSpecified != null;
 
     if (hasPrior) {
-      EngineNumber newCappedValue;
-      if (lastSpecified.hasEquipmentUnits()) {
-        BigDecimal factor = amount.getValue().divide(BigDecimal.valueOf(100));
-        newCappedValue = new EngineNumber(
-            lastSpecified.getValue().multiply(factor),
-            lastSpecified.getUnits()
-        );
-      } else {
-        EngineNumber percentPriorYear = new EngineNumber(amount.getValue(), "% prior year");
-        newCappedValue = unitConverter.convert(percentPriorYear, lastSpecified.getUnits());
-      }
+      BigDecimal factor = amount.getValue().divide(BigDecimal.valueOf(100));
+      EngineNumber newCappedValue = new EngineNumber(
+          lastSpecified.getValue().multiply(factor),
+          lastSpecified.getUnits()
+      );
 
       EngineNumber currentInKg = unitConverter.convert(currentValueRaw, "kg");
       EngineNumber newCappedInKg = unitConverter.convert(newCappedValue, "kg");

--- a/engine/src/main/java/org/kigalisim/engine/support/LimitExecutor.java
+++ b/engine/src/main/java/org/kigalisim/engine/support/LimitExecutor.java
@@ -286,8 +286,18 @@ public class LimitExecutor {
     boolean hasPrior = lastSpecified != null;
 
     if (hasPrior) {
-      EngineNumber percentPriorYear = new EngineNumber(amount.getValue(), "% prior year");
-      EngineNumber newCappedValue = unitConverter.convert(percentPriorYear, lastSpecified.getUnits());
+      EngineNumber newCappedValue;
+      if (lastSpecified.hasEquipmentUnits()) {
+        // The last-specified value is in equipment units. Applying a percent here must scale the
+        // user-specified unit count (e.g. 90% of 1000 units = 900 units), NOT convert the percent
+        // against the population base, which would make the cap enormous and non-binding.
+        BigDecimal factor = amount.getValue().divide(BigDecimal.valueOf(100));
+        newCappedValue = new EngineNumber(
+            lastSpecified.getValue().multiply(factor), lastSpecified.getUnits());
+      } else {
+        EngineNumber percentPriorYear = new EngineNumber(amount.getValue(), "% prior year");
+        newCappedValue = unitConverter.convert(percentPriorYear, lastSpecified.getUnits());
+      }
 
       EngineNumber currentInKg = unitConverter.convert(currentValueRaw, "kg");
       EngineNumber newCappedInKg = unitConverter.convert(newCappedValue, "kg");

--- a/engine/src/test/java/org/kigalisim/validate/CapLiveTests.java
+++ b/engine/src/test/java/org/kigalisim/validate/CapLiveTests.java
@@ -947,4 +947,106 @@ public class CapLiveTests {
         "Virgin should be higher when recycling is limited (was "
         + limitRecycleVirginYear2 + " vs BAU " + bauVirginYear2 + ")");
   }
+
+  /**
+   * Test that in year 10, a permit capping SubA domestic to 90 % (with displacement to SubB)
+   * results in lower SubA consumption than BAU.
+   *
+   * @throws IOException If the QTA file cannot be read.
+   */
+  @Test
+  public void testCapPercentDisplaceSubstanceLowerThanBauPercent() throws IOException {
+    String qtaPath = "../examples/cap_percent_displace_substance.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    Stream<EngineResult> bauResults = KigaliSimFacade.runScenario(program, "BAU", progress -> {});
+    List<EngineResult> bauResultsList = bauResults.collect(Collectors.toList());
+
+    Stream<EngineResult> permitResults =
+        KigaliSimFacade.runScenario(program, "With Permit Percent", progress -> {});
+    List<EngineResult> permitResultsList = permitResults.collect(Collectors.toList());
+
+    EngineResult bauSubA = LiveTestsUtil.getResult(bauResultsList.stream(), 10, "Test", "SubA");
+    EngineResult permitSubA =
+        LiveTestsUtil.getResult(permitResultsList.stream(), 10, "Test", "SubA");
+
+    assertNotNull(bauSubA, "Should have BAU result for Test/SubA in year 10");
+    assertNotNull(permitSubA, "Should have permit result for Test/SubA in year 10");
+
+    double bauConsumption = bauSubA.getConsumption().getValue().doubleValue();
+    double permitConsumption = permitSubA.getConsumption().getValue().doubleValue();
+
+    assertTrue(permitConsumption < bauConsumption,
+        "Cap with % should give lower SubA consumption than BAU in year 10 (was "
+        + permitConsumption + " vs BAU " + bauConsumption + ")");
+  }
+
+  /**
+   * Test that in year 10, a permit capping SubA domestic to 90 % prior year (with displacement to
+   * SubB) results in lower SubA consumption than BAU.
+   *
+   * @throws IOException If the QTA file cannot be read.
+   */
+  @Test
+  public void testCapPercentDisplaceSubstanceLowerThanBauPriorYear() throws IOException {
+    String qtaPath = "../examples/cap_percent_displace_substance.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    Stream<EngineResult> bauResults = KigaliSimFacade.runScenario(program, "BAU", progress -> {});
+    List<EngineResult> bauResultsList = bauResults.collect(Collectors.toList());
+
+    Stream<EngineResult> permitResults =
+        KigaliSimFacade.runScenario(program, "With Permit Prior Year", progress -> {});
+    List<EngineResult> permitResultsList = permitResults.collect(Collectors.toList());
+
+    EngineResult bauSubA = LiveTestsUtil.getResult(bauResultsList.stream(), 10, "Test", "SubA");
+    EngineResult permitSubA =
+        LiveTestsUtil.getResult(permitResultsList.stream(), 10, "Test", "SubA");
+
+    assertNotNull(bauSubA, "Should have BAU result for Test/SubA in year 10");
+    assertNotNull(permitSubA, "Should have permit result for Test/SubA in year 10");
+
+    double bauConsumption = bauSubA.getConsumption().getValue().doubleValue();
+    double permitConsumption = permitSubA.getConsumption().getValue().doubleValue();
+
+    assertTrue(permitConsumption < bauConsumption,
+        "Cap with % prior year should give lower SubA consumption than BAU in year 10 (was "
+        + permitConsumption + " vs BAU " + bauConsumption + ")");
+  }
+
+  /**
+   * Test that in year 10, a permit capping SubA domestic to 90 % current (with displacement to
+   * SubB) results in lower SubA consumption than BAU.
+   *
+   * @throws IOException If the QTA file cannot be read.
+   */
+  @Test
+  public void testCapPercentDisplaceSubstanceLowerThanBauCurrent() throws IOException {
+    String qtaPath = "../examples/cap_percent_displace_substance.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    Stream<EngineResult> bauResults = KigaliSimFacade.runScenario(program, "BAU", progress -> {});
+    List<EngineResult> bauResultsList = bauResults.collect(Collectors.toList());
+
+    Stream<EngineResult> permitResults =
+        KigaliSimFacade.runScenario(program, "With Permit Current", progress -> {});
+    List<EngineResult> permitResultsList = permitResults.collect(Collectors.toList());
+
+    EngineResult bauSubA = LiveTestsUtil.getResult(bauResultsList.stream(), 10, "Test", "SubA");
+    EngineResult permitSubA =
+        LiveTestsUtil.getResult(permitResultsList.stream(), 10, "Test", "SubA");
+
+    assertNotNull(bauSubA, "Should have BAU result for Test/SubA in year 10");
+    assertNotNull(permitSubA, "Should have permit result for Test/SubA in year 10");
+
+    double bauConsumption = bauSubA.getConsumption().getValue().doubleValue();
+    double permitConsumption = permitSubA.getConsumption().getValue().doubleValue();
+
+    assertTrue(permitConsumption < bauConsumption,
+        "Cap with % current should give lower SubA consumption than BAU in year 10 (was "
+        + permitConsumption + " vs BAU " + bauConsumption + ")");
+  }
 }

--- a/examples/cap_percent_displace_substance.qta
+++ b/examples/cap_percent_displace_substance.qta
@@ -1,0 +1,94 @@
+start default
+
+  define application "Test"
+
+    uses substance "SubA"
+      enable domestic
+      initial charge with 1 kg / unit for domestic
+      initial charge with 0 kg / unit for import
+      initial charge with 0 kg / unit for export
+      equals 1 kgCO2e / kg
+      equals 1 kwh / unit
+      set domestic to 1000 units during year 1
+      retire 5 % / year
+      recharge 5 % of priorEquipment with 0.85 kg / unit
+    end substance
+
+
+    uses substance "SubB"
+      enable domestic
+      initial charge with 1 kg / unit for domestic
+      initial charge with 0 kg / unit for import
+      initial charge with 0 kg / unit for export
+      equals 1 kgCO2e / kg
+      equals 1 kwh / unit
+      set sales to 0 units during year 1
+      retire 5 % / year
+      recharge 5 % of priorEquipment with 0.85 kg / unit
+    end substance
+
+  end application
+
+end default
+
+
+start policy "Permit Percent"
+
+  modify application "Test"
+
+    modify substance "SubA"
+      cap domestic to 90% displacing "SubB" during years 3 to 10
+    end substance
+
+  end application
+
+end policy
+
+
+start policy "Permit Prior Year"
+
+  modify application "Test"
+
+    modify substance "SubA"
+      cap domestic to 90% prior year displacing "SubB" during years 3 to 10
+    end substance
+
+  end application
+
+end policy
+
+
+start policy "Permit Current"
+
+  modify application "Test"
+
+    modify substance "SubA"
+      cap domestic to 90% current displacing "SubB" during years 3 to 10
+    end substance
+
+  end application
+
+end policy
+
+
+start simulations
+
+  simulate "BAU"
+  from years 1 to 10
+
+
+  simulate "With Permit Percent"
+    using "Permit Percent"
+  from years 1 to 10
+
+
+  simulate "With Permit Prior Year"
+    using "Permit Prior Year"
+  from years 1 to 10
+
+
+  simulate "With Permit Current"
+    using "Permit Current"
+  from years 1 to 10
+
+end simulations


### PR DESCRIPTION
Have a `%` without `current` or `prior year` default to referring to the original stream mentioned not general population.