### PR TITLE
Ensure substream maintains units intent.

### DIFF
--- a/engine/src/main/java/org/kigalisim/engine/support/LimitExecutor.java
+++ b/engine/src/main/java/org/kigalisim/engine/support/LimitExecutor.java
@@ -429,17 +429,17 @@ public class LimitExecutor {
     String destinationUnits = amount.getUnits();
     boolean usesNewEquipmentBasis = getUsesNewEquipmentBasis(stream, destinationUnits);
 
-    if (!usesNewEquipmentBasis) {
+    if (usesNewEquipmentBasis) {
+      EngineNumber unitsChange = new EngineNumber(
+          amount.getValue().subtract(currentValueInAmountUnits.getValue()),
+          destinationUnits
+      );
+      return unitConverter.convert(unitsChange, "kg").getValue();
+    } else {
       EngineNumber currentInKg = unitConverter.convert(currentValueInAmountUnits, "kg");
       EngineNumber cappedInKg = unitConverter.convert(cappedValueRaw, "kg");
       return cappedInKg.getValue().subtract(currentInKg.getValue());
     }
-
-    EngineNumber unitsChange = new EngineNumber(
-        amount.getValue().subtract(currentValueInAmountUnits.getValue()),
-        destinationUnits
-    );
-    return unitConverter.convert(unitsChange, "kg").getValue();
   }
 
   /**

--- a/engine/src/main/java/org/kigalisim/engine/support/LimitExecutor.java
+++ b/engine/src/main/java/org/kigalisim/engine/support/LimitExecutor.java
@@ -372,7 +372,6 @@ public class LimitExecutor {
       return;
     }
 
-    final EngineNumber currentInKg = unitConverter.convert(currentValueRaw, "kg");
     StreamUpdate update = new StreamUpdateBuilder()
         .setName(stream)
         .setValue(amount)
@@ -385,10 +384,56 @@ public class LimitExecutor {
     setCurrentValueAsLastSpecified(scope, stream);
 
     if (displaceTarget != null) {
-      EngineNumber cappedInKg = engine.getStream(stream);
-      BigDecimal changeInKg = cappedInKg.getValue().subtract(currentInKg.getValue());
+      EngineNumber cappedRaw = engine.getStream(stream);
+      BigDecimal changeInKg = getChangeInKgForDisplacement(
+          unitConverter, stream, currentValueInAmountUnits, cappedRaw, amount);
       displaceExecutor.execute(stream, amount, changeInKg, displaceTarget, displacementType);
     }
+  }
+
+  /**
+   * Computes the change in kg used for a displacement operation after a cap or floor has been
+   * applied.
+   *
+   * <p>For most cases, the stream's raw kg total is stable, so the displaced change is simply the
+   * post-limit raw value minus the pre-limit raw value. This is the path taken for volume-denominated
+   * limits and for sales <em>substreams</em> (domestic/import).</p>
+   *
+   * <p>However, when a <em>units</em>-denominated cap/floor targets a production <em>metastream</em>
+   * ({@code sales} or {@code virgin}) that has recharge (of priorEquipment) or precharge (of
+   * newEquipment) riding on top, that servicing kg is not consistently present in the stream's raw
+   * value at the moment the current value is read versus after the limit is applied. Taking the raw
+   * kg difference in that case yields a small or even sign-inverted change (see
+   * {@link #convertWithServicingAccounted} for the same correction applied to the limit check). For
+   * this case the change is instead computed on the service-free new-equipment basis: the pre-limit
+   * new equipment count is subtracted from the capped unit count and the difference is converted
+   * back to kg.</p>
+   *
+   * @param unitConverter The unit converter configured for the stream
+   * @param stream The stream identifier being capped/floored (e.g., "sales", "domestic")
+   * @param currentValueInAmountUnits The stream's pre-limit value already converted into the
+   *     amount's units with servicing kg backed out (see
+   *     {@link #convertWithServicingAccounted})
+   * @param cappedValueRaw The stream's raw value after the limit was applied
+   * @param amount The cap/floor amount, used both for the limit's units and as the post-limit
+   *     new equipment count
+   * @return The change in kg to pass to the displacement executor
+   */
+  private BigDecimal getChangeInKgForDisplacement(UnitConverter unitConverter, String stream,
+      EngineNumber currentValueInAmountUnits, EngineNumber cappedValueRaw, EngineNumber amount) {
+    String destinationUnits = amount.getUnits();
+    boolean usesNewEquipmentBasis = EngineSupportUtils.isProductionMetastream(stream)
+        && getIfServicingRequiresAccounting(stream, destinationUnits);
+
+    if (!usesNewEquipmentBasis) {
+      EngineNumber currentInKg = unitConverter.convert(currentValueInAmountUnits, "kg");
+      EngineNumber cappedInKg = unitConverter.convert(cappedValueRaw, "kg");
+      return cappedInKg.getValue().subtract(currentInKg.getValue());
+    }
+
+    EngineNumber unitsChange = new EngineNumber(
+        amount.getValue().subtract(currentValueInAmountUnits.getValue()), destinationUnits);
+    return unitConverter.convert(unitsChange, "kg").getValue();
   }
 
   /**
@@ -517,7 +562,6 @@ public class LimitExecutor {
       return;
     }
 
-    final EngineNumber currentInKg = unitConverter.convert(currentValueRaw, "kg");
     StreamUpdate update = new StreamUpdateBuilder()
         .setName(stream)
         .setValue(amount)
@@ -530,8 +574,9 @@ public class LimitExecutor {
     setCurrentValueAsLastSpecified(scope, stream);
 
     if (displaceTarget != null) {
-      EngineNumber newInKg = engine.getStream(stream);
-      BigDecimal changeInKg = newInKg.getValue().subtract(currentInKg.getValue());
+      EngineNumber cappedRaw = engine.getStream(stream);
+      BigDecimal changeInKg = getChangeInKgForDisplacement(
+          unitConverter, stream, currentValueInAmountUnits, cappedRaw, amount);
       displaceExecutor.execute(stream, amount, changeInKg, displaceTarget, displacementType);
     }
   }

--- a/engine/src/main/java/org/kigalisim/engine/support/LimitExecutor.java
+++ b/engine/src/main/java/org/kigalisim/engine/support/LimitExecutor.java
@@ -386,7 +386,12 @@ public class LimitExecutor {
     if (displaceTarget != null) {
       EngineNumber cappedRaw = engine.getStream(stream);
       BigDecimal changeInKg = getChangeInKgForDisplacement(
-          unitConverter, stream, currentValueInAmountUnits, cappedRaw, amount);
+          unitConverter,
+          stream,
+          currentValueInAmountUnits,
+          cappedRaw,
+          amount
+      );
       displaceExecutor.execute(stream, amount, changeInKg, displaceTarget, displacementType);
     }
   }
@@ -422,8 +427,7 @@ public class LimitExecutor {
   private BigDecimal getChangeInKgForDisplacement(UnitConverter unitConverter, String stream,
       EngineNumber currentValueInAmountUnits, EngineNumber cappedValueRaw, EngineNumber amount) {
     String destinationUnits = amount.getUnits();
-    boolean usesNewEquipmentBasis = EngineSupportUtils.isProductionMetastream(stream)
-        && getIfServicingRequiresAccounting(stream, destinationUnits);
+    boolean usesNewEquipmentBasis = getUsesNewEquipmentBasis(stream, destinationUnits);
 
     if (!usesNewEquipmentBasis) {
       EngineNumber currentInKg = unitConverter.convert(currentValueInAmountUnits, "kg");
@@ -432,8 +436,28 @@ public class LimitExecutor {
     }
 
     EngineNumber unitsChange = new EngineNumber(
-        amount.getValue().subtract(currentValueInAmountUnits.getValue()), destinationUnits);
+        amount.getValue().subtract(currentValueInAmountUnits.getValue()),
+        destinationUnits
+    );
     return unitConverter.convert(unitsChange, "kg").getValue();
+  }
+
+  /**
+   * Returns whether the new-equipment basis must be used to compute the change in kg for a
+   * displacement operation on the given production metastream denominated in the given units.
+   *
+   * @param stream The stream identifier being capped/floored (e.g., "sales", "domestic")
+   * @param destinationUnits The units of the cap/floor amount
+   * @return True if the new-equipment basis must be used, false otherwise
+   */
+  private boolean getUsesNewEquipmentBasis(String stream, String destinationUnits) {
+    if (!EngineSupportUtils.isProductionMetastream(stream)) {
+      return false;
+    } else if (!getIfServicingRequiresAccounting(stream, destinationUnits)) {
+      return false;
+    } else {
+      return true;
+    }
   }
 
   /**
@@ -576,7 +600,12 @@ public class LimitExecutor {
     if (displaceTarget != null) {
       EngineNumber cappedRaw = engine.getStream(stream);
       BigDecimal changeInKg = getChangeInKgForDisplacement(
-          unitConverter, stream, currentValueInAmountUnits, cappedRaw, amount);
+          unitConverter,
+          stream,
+          currentValueInAmountUnits,
+          cappedRaw,
+          amount
+      );
       displaceExecutor.execute(stream, amount, changeInKg, displaceTarget, displacementType);
     }
   }

--- a/engine/src/test/java/org/kigalisim/validate/CapLiveTests.java
+++ b/engine/src/test/java/org/kigalisim/validate/CapLiveTests.java
@@ -124,6 +124,52 @@ public class CapLiveTests {
   }
 
   /**
+   * Test that a units-denominated "cap sales ... displacing" with recharge advances the
+   * displacement into the target substance rather than decaying and going negative.
+   *
+   * <p>Setup: SubA sells 1000 units in year 1 (with {@code recharge 5% of priorEquipment});
+   * SubB has zero sales. A policy caps SubA's {@code sales} to 900, 800, 700, 600, 500 units across
+   * years 3-7, displacing "SubB". Each year the cap reduces SubA new equipment by 100 units, so
+   * SubB should pick up roughly 100 units/year of new equipment on top of displace existing
+   * Sub B stock.</p>
+   *
+   * <p>Regression test: with recharge riding on top of the sales stream, the displacement change
+   * was previously computed from the raw kg difference, which is sign-inverted once servicing kg
+   * is present in the capped value. That made SubB's new equipment shrink and go negative instead
+   * of accumulating the displaced units.</p>
+   */
+  @Test
+  public void testCapSalesDisplaceWithRechargeAdvancesSubB() throws IOException {
+    String qtaPath = "../examples/cap_sales_displace_with_recharge.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    Stream<EngineResult> results = KigaliSimFacade.runScenario(
+        program, "With Permit", progress -> {});
+    List<EngineResult> resultsList = results.collect(Collectors.toList());
+
+    EngineResult year3SubB = LiveTestsUtil.getResult(resultsList.stream(), 3, "Test", "SubB");
+    assertNotNull(year3SubB, "Should have result for Test/SubB in year 3");
+    assertEquals(100.0, year3SubB.getPopulationNew().getValue().doubleValue(), 0.0001,
+        "SubB new equipment should be 100 units in year 3 (full 100-unit displacement)");
+
+    // Year after caps continue: SubB must keep accumulating new equipment (positive), never
+    // decaying negative as it did before the fix.
+    EngineResult year6SubB = LiveTestsUtil.getResult(resultsList.stream(), 6, "Test", "SubB");
+    assertNotNull(year6SubB, "Should have result for Test/SubB in year 6");
+    assertTrue(year6SubB.getPopulationNew().getValue().doubleValue() > 300.0,
+        "SubB new equipment should have accumulated past 300 units by year 6, but was "
+            + year6SubB.getPopulationNew().getValue());
+    assertEquals(400.0, year6SubB.getDomestic().getValue().doubleValue(), 0.0001,
+        "SubB domestic sales should reflect the cumulative 400-unit displacement by year 6");
+
+    EngineResult year7SubB = LiveTestsUtil.getResult(resultsList.stream(), 7, "Test", "SubB");
+    assertNotNull(year7SubB, "Should have result for Test/SubB in year 7");
+    assertTrue(year7SubB.getPopulationNew().getValue().doubleValue() > year6SubB.getPopulationNew().getValue().doubleValue(),
+        "SubB new equipment should keep increasing while SubA sales keep being capped");
+  }
+
+  /**
    * Test cap_displace_unit_conversion.qta produces expected values.
    * This tests unit-to-unit displacement conversion.
    */

--- a/examples/cap_sales_displace_with_recharge.qta
+++ b/examples/cap_sales_displace_with_recharge.qta
@@ -1,0 +1,57 @@
+start default
+
+  define application "Test"
+
+    uses substance "SubA"
+      enable domestic
+      initial charge with 1 kg / unit for domestic
+      initial charge with 0 kg / unit for import
+      initial charge with 0 kg / unit for export
+      equals 1 kgCO2e / kg
+      equals 1 kwh / unit
+      set domestic to 1000 units during year 1
+      retire 5 % / year
+      recharge 5 % of priorEquipment with 0.85 kg / unit
+    end substance
+
+    uses substance "SubB"
+      enable domestic
+      initial charge with 1 kg / unit for domestic
+      initial charge with 0 kg / unit for import
+      initial charge with 0 kg / unit for export
+      equals 1 kgCO2e / kg
+      equals 1 kwh / unit
+      set sales to 0 units during year 1
+      retire 5 % / year
+      recharge 5 % of priorEquipment with 0.85 kg / unit
+    end substance
+
+  end application
+
+end default
+
+
+start policy "Permit"
+
+  modify application "Test"
+
+    modify substance "SubA"
+      cap sales to 900 units displacing "SubB" during year 3
+      cap sales to 800 units displacing "SubB" during year 4
+      cap sales to 700 units displacing "SubB" during year 5
+      cap sales to 600 units displacing "SubB" during year 6
+      cap sales to 500 units displacing "SubB" during year 7
+    end substance
+
+  end application
+
+end policy
+
+
+start simulations
+
+  simulate "With Permit"
+    using "Permit"
+  from years 1 to 10
+
+end simulations


### PR DESCRIPTION
Fixes a bug where sales intent was not inferred when mixing import / domestic with sales statements.