### PR TITLE
Fix unit conversion bug in composite stream updates

### DIFF
--- a/engine/src/main/java/org/kigalisim/engine/support/StreamUpdateExecutor.java
+++ b/engine/src/main/java/org/kigalisim/engine/support/StreamUpdateExecutor.java
@@ -172,9 +172,14 @@ public class StreamUpdateExecutor {
     boolean eitherUnits = thisIsUnits || otherIsUnits;
     String targetUnits = eitherUnits ? "units" : value.getUnits();
 
+    // Each substream (domestic / import) can have its own initial charge (kg / unit), so a
+    // converter built for one substream cannot be reused to convert the other substream's
+    // value: doing so divides by the wrong (possibly zero) initial charge.
+    String otherStreamName = "domestic".equals(streamName) ? "import" : "domestic";
     UnitConverter converter = EngineSupportUtils.createUnitConverterWithTotal(engine, streamName);
+    UnitConverter otherConverter = EngineSupportUtils.createUnitConverterWithTotal(engine, otherStreamName);
     EngineNumber valueConverted = converter.convert(value, targetUnits);
-    EngineNumber otherConverted = converter.convert(otherValue, targetUnits);
+    EngineNumber otherConverted = otherConverter.convert(otherValue, targetUnits);
 
     BigDecimal combinedValue = valueConverted.getValue().add(otherConverted.getValue());
     EngineNumber salesIntent = new EngineNumber(combinedValue, targetUnits);

--- a/engine/src/test/java/org/kigalisim/validate/ReplaceLiveTests.java
+++ b/engine/src/test/java/org/kigalisim/validate/ReplaceLiveTests.java
@@ -508,4 +508,29 @@ public class ReplaceLiveTests {
     // Note: Target substances may remain at zero if they have no initial import/sales in the QTA setup
     // The key validation is that replaced substances are reduced but not eliminated entirely
   }
+
+  /**
+   * Test that replacing import into a substance using "recharge X% of priorEquipment"
+   * still results in nonzero consumption for the target substance in later years.
+   *
+   * <p>This reproduces a divide-by-zero bug reported against a script where SubB (the
+   * "replace" target) starts with a small sales volume and both substances use
+   * "recharge % of priorEquipment". Under "With Replace", SubB should end up with
+   * more than 0 kg of consumption by year 10.</p>
+   */
+  @Test
+  public void testReplaceIntoPriorEquipmentRechargeTarget() throws IOException {
+    String qtaPath = "../examples/replace_import_priorequipment_recharge.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    Stream<EngineResult> results = KigaliSimFacade.runScenario(program, "With Replace", progress -> {});
+    List<EngineResult> resultsList = results.collect(Collectors.toList());
+
+    EngineResult resultSubbYear10 = LiveTestsUtil.getResult(resultsList.stream(), 10, "Test", "SubB");
+    assertNotNull(resultSubbYear10, "Should have result for Test/SubB in year 10");
+
+    assertTrue(resultSubbYear10.getConsumption().getValue().doubleValue() > 0.0,
+        "SubB should have more than 0 kg of consumption in year 10 under With Replace");
+  }
 }

--- a/examples/replace_import_priorequipment_recharge.qta
+++ b/examples/replace_import_priorequipment_recharge.qta
@@ -1,0 +1,57 @@
+start default
+
+  define application "Test"
+
+    uses substance "SubA"
+      enable import
+      initial charge with 0 kg / unit for domestic
+      initial charge with 1 kg / unit for import
+      initial charge with 0 kg / unit for export
+      equals 1 kgCO2e / kg
+      equals 1 kwh / unit
+      set sales to 10 units during year 1
+      change sales by 1 units during years 2 to 10
+      retire 5 % / year
+      recharge 5 % of priorEquipment with 0.85 kg / unit
+    end substance
+
+
+    uses substance "SubB"
+      enable import
+      initial charge with 1 kg / unit for import
+      equals 1 kgCO2e / kg
+      equals 1 kwh / unit
+      set sales to 1 units during year 1
+      retire 5 % / year
+      recharge 5 % of priorEquipment with 0.85 kg / unit
+    end substance
+
+  end application
+
+end default
+
+
+start policy "Replace"
+
+  modify application "Test"
+
+    modify substance "SubA"
+      replace 10 % of import with "SubB" during years 2 to 10
+    end substance
+
+  end application
+
+end policy
+
+
+start simulations
+
+  simulate "BAU"
+  from years 1 to 10
+
+
+  simulate "With Replace"
+    using "Replace"
+  from years 1 to 10
+
+end simulations


### PR DESCRIPTION
## Summary
Fixed a divide-by-zero bug in `StreamUpdateExecutor` where unit converters built for one substream (domestic/import) were incorrectly reused to convert values from another substream with a different initial charge specification.

## Key Changes
- **StreamUpdateExecutor.java**: Modified `updateComposite()` method to create separate unit converters for each substream (domestic and import) instead of reusing a single converter. Each substream can have its own initial charge (kg/unit), so using the wrong converter would divide by an incorrect (possibly zero) initial charge value.

- **ReplaceLiveTests.java**: Added `testReplaceIntoPriorEquipmentRechargeTarget()` test case that validates the fix. This test reproduces the original bug scenario where:
  - SubB (target substance) starts with small sales volume
  - Both substances use "recharge % of priorEquipment"
  - Under a "Replace" policy, SubB should accumulate non-zero consumption by year 10

- **replace_import_priorequipment_recharge.qta**: Added example QTA file demonstrating the scenario that triggered the bug, with two substances using import and prior equipment recharge.

## Implementation Details
The fix ensures that when updating composite streams (combining domestic and import values), each substream's value is converted using a converter built specifically for that substream's initial charge specification, preventing incorrect unit conversions that could result in division by zero or other calculation errors.

https://claude.ai/code/session_01JdT7AoEZuGmxkSxGTjZHEo