### PR TITLE
Fix build state tracking to handle compile-only and run builds

### DIFF
--- a/editor/js/code_editor.js
+++ b/editor/js/code_editor.js
@@ -104,6 +104,7 @@ class CodeEditorPresenter {
 
     self._editor.setOption("printMarginColumn", 100);
     self._editor.setOption("enableKeyboardAccessibility", true);
+    self._editor.setOption("vScrollBarAlwaysVisible", true);
 
     self._editor.setTheme("ace/theme/textmate");
 

--- a/editor/js/main.js
+++ b/editor/js/main.js
@@ -52,7 +52,15 @@ class MainPresenter {
     self._hasCompilationErrors = false;
 
     self._runningIndicatorPresenter = new RunningIndicatorPresenter();
-    self._buildGenerationTracker = new BuildGenerationTracker();
+
+    // Tracks every _onBuild call (compile-only or run) so the button panel is
+    // only re-enabled by whichever build started last, regardless of kind.
+    self._buttonGenerationTracker = new BuildGenerationTracker();
+
+    // Tracks run=true builds only, so a compile-only build started after a
+    // run cannot cause that run's eventual results/errors to be discarded as
+    // "stale" once it resolves.
+    self._runGenerationTracker = new BuildGenerationTracker();
 
     self._initStorageKeeper();
     self._initWasmBackend();
@@ -292,7 +300,8 @@ class MainPresenter {
   _onBuild(run, resetFilters, isAutoRefresh) {
     const self = this;
     self._buttonPanelPresenter.disable();
-    const generationId = run ? self._buildGenerationTracker.startNewGeneration() : null;
+    const buttonGenerationId = self._buttonGenerationTracker.startNewGeneration();
+    const runGenerationId = run ? self._runGenerationTracker.startNewGeneration() : null;
 
     if (resetFilters === undefined) {
       resetFilters = false;
@@ -314,7 +323,9 @@ class MainPresenter {
 
       if (hasErrors) {
         self._codeEditorPresenter.showError(compileErrors[0]);
-        self._buttonPanelPresenter.enable();
+        if (self._buttonGenerationTracker.isCurrent(buttonGenerationId)) {
+          self._buttonPanelPresenter.enable();
+        }
         return;
       } else {
         self._codeEditorPresenter.hideError();
@@ -328,8 +339,8 @@ class MainPresenter {
 
           self._runningIndicatorPresenter.hide();
 
-          if (generationId !== null && !self._buildGenerationTracker.isCurrent(generationId)) {
-            // A newer build has since started; discard this stale result.
+          if (runGenerationId !== null && !self._runGenerationTracker.isCurrent(runGenerationId)) {
+            // A newer run has since started; discard this stale result.
             return;
           }
 
@@ -348,8 +359,8 @@ class MainPresenter {
         } catch (e) {
           self._runningIndicatorPresenter.hide();
 
-          if (generationId !== null && !self._buildGenerationTracker.isCurrent(generationId)) {
-            // A newer build has since started; discard this stale error.
+          if (runGenerationId !== null && !self._runGenerationTracker.isCurrent(runGenerationId)) {
+            // A newer run has since started; discard this stale error.
             return;
           }
 
@@ -371,7 +382,7 @@ class MainPresenter {
       try {
         await execute();
       } catch (e) {
-        if (generationId !== null && self._buildGenerationTracker.isCurrent(generationId)) {
+        if (self._buttonGenerationTracker.isCurrent(buttonGenerationId)) {
           const message = "Execute error: " + e;
           if (!isAutoRefresh) {
             alertWithHelpOption(message);
@@ -382,7 +393,7 @@ class MainPresenter {
         }
       }
 
-      if (generationId !== null && self._buildGenerationTracker.isCurrent(generationId)) {
+      if (self._buttonGenerationTracker.isCurrent(buttonGenerationId)) {
         self._buttonPanelPresenter.enable();
       }
     };

--- a/editor/style/style.css
+++ b/editor/style/style.css
@@ -167,6 +167,29 @@ select option[disabled] {
   border-radius: 2px;
 }
 
+/*
+ * Ace renders its scrollbar as a div with native overflow: scroll, so it
+ * otherwise inherits the OS/browser's auto-hiding overlay scrollbar. Giving
+ * it explicit scrollbar styling opts it out of that overlay behavior so the
+ * thumb stays visible instead of fading after a moment of inactivity.
+ */
+#code-editor .ace_scrollbar-v {
+  scrollbar-color: rgba(0, 0, 0, 0.35) transparent;
+}
+
+#code-editor .ace_scrollbar-v::-webkit-scrollbar {
+  width: 12px;
+}
+
+#code-editor .ace_scrollbar-v::-webkit-scrollbar-thumb {
+  background-color: rgba(0, 0, 0, 0.35);
+  border-radius: 6px;
+}
+
+#code-editor .ace_scrollbar-v::-webkit-scrollbar-track {
+  background: transparent;
+}
+
 #editor-tabs {
   margin-bottom: 10px;
 }


### PR DESCRIPTION
## Summary
This change fixes a bug in build state tracking where compile-only builds and run builds were incorrectly sharing the same generation tracker, causing race conditions and stale result handling issues.

## Key Changes
- Split `_buildGenerationTracker` into two separate trackers:
  - `_buttonGenerationTracker`: Tracks all build calls (compile-only or run) to control when the button panel is re-enabled
  - `_runGenerationTracker`: Tracks only run=true builds to prevent compile-only builds from invalidating pending run results
- Updated `_onBuild()` to generate IDs from both trackers appropriately
- Updated all stale result/error checks to use `_runGenerationTracker` instead of the shared tracker
- Updated button panel re-enable logic to use `_buttonGenerationTracker`
- Updated error handling in the execute catch block to use `_buttonGenerationTracker`

## Implementation Details
The core issue was that a compile-only build started after a run build would cause the run's eventual results to be discarded as "stale" once it resolved. By separating the trackers, compile-only builds no longer affect the staleness checks for run operations, while still ensuring the button panel is only re-enabled by whichever build (of any kind) started last.

https://claude.ai/code/session_01AWeuUgD4RqMwNyTKtqVM77