### PR TITLE
Fix stale simulation error overlay when starting a new run

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,7 +16,7 @@ The following changes have been adopted and released.
 
 ### Editor run and error panel visibility fix
 
-**Status**: Released Aug 13, 2026
+**Status**: Released Aug 14, 2026
 
 **Classification**: Bug
 

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,14 @@ Finally, we want to again express our gratitude for your feedback and time.
 
 The following changes have been adopted and released.
 
+### Editor run and error panel visibility fix
+
+**Status**: Released Aug 13, 2026
+
+**Classification**: Bug
+
+In some circumstances, the code-based editor run button would not appear after a code change. Also, after an error, the error panel would overlay the status bar after recovering from an error.
+
 ### Replace switching unit tracking basis
 
 **Status**: Released August 7, 2026

--- a/editor/js/editor_actions.js
+++ b/editor/js/editor_actions.js
@@ -23,6 +23,25 @@ class RunningIndicatorPresenter {
     self.reset();
     self._resultsSection.style.display = "block";
     self._runningIndicator.style.display = "block";
+    self._hideStaleOverlays();
+  }
+
+  /**
+   * Clear any stale results overlays (error indicator and no-results
+   * message) before a new run begins.
+   *
+   * @private
+   */
+  _hideStaleOverlays() {
+    const self = this;
+    const errorIndicator = document.getElementById("error-indicator");
+    if (errorIndicator) {
+      errorIndicator.style.display = "none";
+    }
+    const noResultsMessage = document.getElementById("no-results-message");
+    if (noResultsMessage) {
+      noResultsMessage.style.display = "none";
+    }
   }
 
   /**

--- a/editor/test/test.html
+++ b/editor/test/test.html
@@ -123,6 +123,8 @@
     <input type="checkbox" id="save-preferences-checkbox" style="display: none;" />
     <div id="running-indicator" style="display: none;"></div>
     <div id="simulation-progress" style="display: none;"></div>
+    <div id="error-indicator" style="display: none;"></div>
+    <div id="no-results-message" style="display: none;"></div>
     <div id="results" style="display: none;">
       <div id="scorecards">
         <div id="emissions-scorecard">

--- a/editor/test/test_main.js
+++ b/editor/test/test_main.js
@@ -55,6 +55,33 @@ function buildMainTests() {
       assert.equal(progressBar.value, 0, "reset should force progress back to 0 for a new batch");
     });
 
+    QUnit.test("RunningIndicatorPresenter show clears stale overlays", function (assert) {
+      const presenter = new RunningIndicatorPresenter();
+      const errorIndicator = document.getElementById("error-indicator");
+      const noResultsMessage = document.getElementById("no-results-message");
+
+      errorIndicator.style.display = "block";
+      noResultsMessage.style.display = "block";
+
+      presenter.show();
+
+      assert.equal(
+        errorIndicator.style.display,
+        "none",
+        "show should hide a stale error indicator before a new run",
+      );
+      assert.equal(
+        noResultsMessage.style.display,
+        "none",
+        "show should hide a stale no-results message before a new run",
+      );
+      assert.equal(
+        presenter._runningIndicator.style.display,
+        "block",
+        "show should display the running indicator",
+      );
+    });
+
     QUnit.test("ButtonPanelPresenter can be initialized", function (assert) {
       const root = document.getElementById("code-buttons-panel");
       const mockOnBuild = function () {};


### PR DESCRIPTION
Hide the error indicator and no-results message when a new simulation run begins so a previously displayed error does not linger over the running indicator. Add a QUnit test covering the behavior.