### PR TITLE
Prepare 0.2.2 pre-release updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ This can be run using the editor tab at https://kigalisim.org/ or locally via `j
 Developers can continue their work by going to the [User Guide](https://kigalisim.org/guide/) which had information on other features. See also the [formal QubecTalk language specification](https://kigalisim.org/guide/qubectalk.pdf).
 
 ### LLM assistants
-If desired, AI coding assistants or chatbots can help in using Kigali Sim. We implement the [llms.txt specification](https://llmstxt.org), a standard that allows users to bring their own LLM assistants to the tool. Direct your AI to read `https://kigalisim.org/llms-full.txt?v=20260804` and / or `https://kigalisim.org/llms.txt?v=20260804`.
+If desired, AI coding assistants or chatbots can help in using Kigali Sim. We implement the [llms.txt specification](https://llmstxt.org), a standard that allows users to bring their own LLM assistants to the tool. Direct your AI to read `https://kigalisim.org/llms-full.txt?v=20260825` and / or `https://kigalisim.org/llms.txt?v=20260825`.
 
 <br>
 

--- a/docs/guide/tutorial_03a.html
+++ b/docs/guide/tutorial_03a.html
@@ -51,10 +51,10 @@
           In this tutorial series, we have used <a href="https://claude.ai/">Claude</a>. However, in practice, most AI assistants can help with Kigali Sim using a standard called <a href="https://llmstxt.org/">llms.txt</a>. So, to get AI ready to go, please create a new chat session. Then, tell it to look up information about Kigali Sim through a message like this:
         </p>
 
-        <pre class="prompt-code"><code>Hello! I would like help with building a Kigali Sim simulation. Please read https://kigalisim.org/llms-full.txt?v=20260804 to learn more. Please stick to only features compatible with the UI editor.</code></pre>
+        <pre class="prompt-code"><code>Hello! I would like help with building a Kigali Sim simulation. Please read https://kigalisim.org/llms-full.txt?v=20260825 to learn more. Please stick to only features compatible with the UI editor.</code></pre>
 
         <p>
-          Need a little cheat? <a href="tutorial_02.qta" download>Download the Tutorial 2</a> file here. Also, for more capable assistants like Claude, this is enough. However, some assistants cannot access the full internet or won't know how to work with this kind of file out of the box. If your assistant is having issues, instead, attach the <a href="https://kigalisim.org/llms-full.txt?v=20260804" download>Kigali Sim llms-full.txt</a> file as an attachment!
+          Need a little cheat? <a href="tutorial_02.qta" download>Download the Tutorial 2</a> file here. Also, for more capable assistants like Claude, this is enough. However, some assistants cannot access the full internet or won't know how to work with this kind of file out of the box. If your assistant is having issues, instead, attach the <a href="https://kigalisim.org/llms-full.txt?v=20260825" download>Kigali Sim llms-full.txt</a> file as an attachment!
         </p>
 
         <p>

--- a/docs/guide/tutorial_04a.html
+++ b/docs/guide/tutorial_04a.html
@@ -61,10 +61,10 @@
           <strong>If you are new to the AI</strong> or just want to start fresh, create a new chat session. Then, tell it to look up information about Kigali Sim through a message like this:
         </p>
 
-        <pre class="prompt-code"><code>Hello! I would like help with building a Kigali Sim simulation. Please read https://kigalisim.org/llms-full.txt?v=20260804 to learn more. Please stick to only features compatible with the UI editor.</code></pre>
+        <pre class="prompt-code"><code>Hello! I would like help with building a Kigali Sim simulation. Please read https://kigalisim.org/llms-full.txt?v=20260825 to learn more. Please stick to only features compatible with the UI editor.</code></pre>
 
         <p>
-          Need a little cheat? <a href="tutorial_03.qta" download>Download the Tutorial 3</a> file here. Also, for more capable assistants like Claude, this is enough. However, some assistants cannot access the full internet or won't know how to work with this kind of file out of the box. If your assistant is having issues, instead, attach the <a href="https://kigalisim.org/llms-full.txt?v=20260804" download>Kigali Sim llms-full.txt</a> file as an attachment!
+          Need a little cheat? <a href="tutorial_03.qta" download>Download the Tutorial 3</a> file here. Also, for more capable assistants like Claude, this is enough. However, some assistants cannot access the full internet or won't know how to work with this kind of file out of the box. If your assistant is having issues, instead, attach the <a href="https://kigalisim.org/llms-full.txt?v=20260825" download>Kigali Sim llms-full.txt</a> file as an attachment!
         </p>
 
         <p>

--- a/docs/guide/tutorial_06a.html
+++ b/docs/guide/tutorial_06a.html
@@ -55,10 +55,10 @@
           In this case, let's create a new chat session. Then, tell it to look up information about Kigali Sim through a message like this:
         </p>
 
-        <pre class="prompt-code"><code>Hello! I would like help with building a Kigali Sim simulation. Please read https://kigalisim.org/llms-full.txt?v=20260804 to learn more. Please stick to only features compatible with the UI editor.</code></pre>
+        <pre class="prompt-code"><code>Hello! I would like help with building a Kigali Sim simulation. Please read https://kigalisim.org/llms-full.txt?v=20260825 to learn more. Please stick to only features compatible with the UI editor.</code></pre>
 
         <p>
-          Need a little cheat? <a href="tutorial_05.qta" download>Download the Tutorial 5</a> file here. Also, for more capable assistants like Claude, this is enough. However, some assistants cannot access the full internet or won't know how to work with this kind of file out of the box. If your assistant is having issues, instead, attach the <a href="https://kigalisim.org/llms-full.txt?v=20260804" download>Kigali Sim llms-full.txt</a> file as an attachment!
+          Need a little cheat? <a href="tutorial_05.qta" download>Download the Tutorial 5</a> file here. Also, for more capable assistants like Claude, this is enough. However, some assistants cannot access the full internet or won't know how to work with this kind of file out of the box. If your assistant is having issues, instead, attach the <a href="https://kigalisim.org/llms-full.txt?v=20260825" download>Kigali Sim llms-full.txt</a> file as an attachment!
         </p>
 
         <p>

--- a/docs/guide/tutorial_11.html
+++ b/docs/guide/tutorial_11.html
@@ -84,7 +84,7 @@
               <a href="https://chatgpt.com/">ChatGPT</a> tends to perform well if given an example. Consider providing a tutorial qta file in your initial prompt like so:
             </p>
 
-            <pre class="prompt-code"><code>Hello! Please review https://preview.kigalisim.org/llms-full.txt?v=20260804 and an example simulation at https://kigalisim.org/guide/tutorial_02.qta. Please follow the structure of that Tutorial 2 with similar keywords and layout in order to write correct QubecTalk code though you may use the other keywords and language features mentioned in llms-full.txt. Please review and then we will build a simulation together.</code></pre>
+            <pre class="prompt-code"><code>Hello! Please review https://preview.kigalisim.org/llms-full.txt?v=20260825 and an example simulation at https://kigalisim.org/guide/tutorial_02.qta. Please follow the structure of that Tutorial 2 with similar keywords and layout in order to write correct QubecTalk code though you may use the other keywords and language features mentioned in llms-full.txt. Please review and then we will build a simulation together.</code></pre>
 
             <p>
               Depending on where you use ChatGPT, it may just give you back code instead of a file. This can be copied and pasted into the <strong>Editor</strong> tab. If you instructed ChatGPT to only use UI-editor compatible code, you can update the code and go back to the <strong>Designer</strong> tab to continue with UI-based authoring.
@@ -108,7 +108,7 @@
               Different versions of copilot might perform differently. See <a href="https://copilot.microsoft.com/">copilot.microsoft.com</a>. In general, Copilot tends to work best when working from an example so you may want to start with a prompt like this:
             </p>
 
-            <pre class="prompt-code"><code>Hello! Please review https://preview.kigalisim.org/llms-full.txt?v=20260804 and an example simulation at https://kigalisim.org/guide/tutorial_02.qta. Please follow the structure of that Tutorial 2 with similar keywords and layout in order to write correct QubecTalk code though you may use the other keywords and language features mentioned in llms-full.txt. Please review and then we will build a simulation together.</code></pre>
+            <pre class="prompt-code"><code>Hello! Please review https://preview.kigalisim.org/llms-full.txt?v=20260825 and an example simulation at https://kigalisim.org/guide/tutorial_02.qta. Please follow the structure of that Tutorial 2 with similar keywords and layout in order to write correct QubecTalk code though you may use the other keywords and language features mentioned in llms-full.txt. Please review and then we will build a simulation together.</code></pre>
 
             <p>
               Depending on where you use Copilot, it may just give you back code instead of a file. This can be copied and pasted into the <strong>Editor</strong> tab. If you instructed Copilot to only use UI-editor compatible code, you can update the code and go back to the <strong>Designer</strong> tab to continue with UI-based authoring.
@@ -123,7 +123,7 @@
               Visit <a href="https://chat.deepseek.com/">chat.deepseek.com</a>. DeepSeek tends to work fairly well but may require a reminder to add the simulations stanza like so:
             </p>
 
-            <pre class="prompt-code"><code>Hello! Please review https://preview.kigalisim.org/llms-full.txt?v=20260804. Then, we will build a simulation together. Please be sure to include the simulation stanza like seen in https://kigalisim.org/guide/tutorial_02.qta.</code></pre>
+            <pre class="prompt-code"><code>Hello! Please review https://preview.kigalisim.org/llms-full.txt?v=20260825. Then, we will build a simulation together. Please be sure to include the simulation stanza like seen in https://kigalisim.org/guide/tutorial_02.qta.</code></pre>
           </div>
         </details>
 
@@ -178,10 +178,10 @@
           At minimum, you should tell your AI to read <a href="https://kigalisim.org/llms.txt" target="_blank">kigalisim.org/llms.txt</a> but we find that providing both <code>llms.txt</code> and <code>llms-full.txt</code> is helpful. Here is how you might want to start.
         </p>
 
-        <pre class="prompt-code"><code>Hello! Please review https://preview.kigalisim.org/llms-full.txt?v=20260804. Then, we will build a simulation together.</code></pre>
+        <pre class="prompt-code"><code>Hello! Please review https://preview.kigalisim.org/llms-full.txt?v=20260825. Then, we will build a simulation together.</code></pre>
 
         <p>
-          <strong>Note</strong>: You may want to review the <a href="#assistants">assistants</a> section for tips on making your specific AI assistant work well. Also, the use of the version (v=20260804) is optional but we recommend it to ensure you have the latest copy.
+          <strong>Note</strong>: You may want to review the <a href="#assistants">assistants</a> section for tips on making your specific AI assistant work well. Also, the use of the version (v=20260825) is optional but we recommend it to ensure you have the latest copy.
         </p>
 
         <p>

--- a/docs/guide/tutorial_11a.html
+++ b/docs/guide/tutorial_11a.html
@@ -100,7 +100,7 @@ We will focus on Domestic Refrigeration first. This is a hypothetical country wi
 
 A few pieces of guidance:
 
- - Before starting, please read https://kigalisim.org/llms-full.txt?v=20260804 to learn more about Kigali Sim.
+ - Before starting, please read https://kigalisim.org/llms-full.txt?v=20260825 to learn more about Kigali Sim.
  - Please use both census data for equipment population and the imports in tonnes if possible to have both datasets support each other.
  - Please lean on Kigali Sim to do calculations where it can be useful including unit conversions, determining substance allocation across different needs, calculating populations, etc.
  - Please use the `.txt` extension for qubectalk files so they are easier to read in chat.

--- a/editor/index.html
+++ b/editor/index.html
@@ -167,12 +167,12 @@
           <p>AI assistants can help you build Kigali Sim simulations by reading and writing QubecTalk code. Direct your assistant to read our documentation and then provide your code for help. For a step-by-step guide, see <a href="/guide/tutorial_11.html" target="_blank">Tutorial 11: AI Coding Assistants</a>.</p>
           <p><strong>Documentation URLs:</strong></p>
           <ul>
-            <li><a href="https://kigalisim.org/llms-full.txt?v=20260804" target="_blank">https://kigalisim.org/llms-full.txt?v=20260804</a> — comprehensive documentation (recommended)</li>
-            <li><a href="https://kigalisim.org/llms.txt?v=20260804" target="_blank">https://kigalisim.org/llms.txt?v=20260804</a> — index with links to tutorials and references</li>
+            <li><a href="https://kigalisim.org/llms-full.txt?v=20260825" target="_blank">https://kigalisim.org/llms-full.txt?v=20260825</a> — comprehensive documentation (recommended)</li>
+            <li><a href="https://kigalisim.org/llms.txt?v=20260825" target="_blank">https://kigalisim.org/llms.txt?v=20260825</a> — index with links to tutorials and references</li>
           </ul>
           <details>
             <summary>More details</summary>
-            <p><strong>Version Parameters:</strong> The version parameter (e.g., ?v=20260804) is optional but recommended. It helps ensure your AI assistant accesses the latest documentation by avoiding cached versions.</p>
+            <p><strong>Version Parameters:</strong> The version parameter (e.g., ?v=20260825) is optional but recommended. It helps ensure your AI assistant accesses the latest documentation by avoiding cached versions.</p>
             <p><strong>Tip:</strong> For LLMs which cannot access the internet, you can <a href="/llms-full.txt" download>download llms-full.txt</a> and provide it as an attachment to your AI assistant.</p>
             <p><strong>Note:</strong> Using AI assistants is entirely optional. Their use is subject to their respective terms of service and privacy policies.</p>
             <p><strong>Privacy:</strong> Using an AI assistant may involve disclosing information about your simulation to the AI and its cloud provider. Be sure to check their privacy policies and any policies negotiated by your organization.</p>
@@ -185,7 +185,7 @@
         <dialog id="ai-designer-dialog">
           <h2>AI Assistant</h2>
           <p>AI assistants can help you build Kigali Sim simulations. Start a chat with any AI assistant and send a message like this:</p>
-          <pre class="prompt-code"><code>Hello! I would like help with building a Kigali Sim simulation. Please read https://kigalisim.org/llms-full.txt?v=20260804 to learn more. Please stick to only features compatible with the UI editor.</code></pre>
+          <pre class="prompt-code"><code>Hello! I would like help with building a Kigali Sim simulation. Please read https://kigalisim.org/llms-full.txt?v=20260825 to learn more. Please stick to only features compatible with the UI editor.</code></pre>
           <p>For a step-by-step walkthrough, see <a href="/guide/tutorial_03a.html" target="_blank">Tutorial 3a: Multiple Substances with AI</a>.</p>
           <details>
             <summary>More details</summary>
@@ -743,6 +743,9 @@
                                   class="retirement-units-input"
                                   aria-label="Units of equipment annual retirement"
                                 >
+                                  <option value="%">%</option>
+                                  <option value="year old mean weibull">year old (mean life, Weibull)</option>
+                                  <option value="year old exact">year old (exact)</option>
                                   <option value="kg">kg</option>
                                   <option value="mt">mt</option>
                                   <option value="tCO2e">tCO2e</option>
@@ -761,12 +764,9 @@
                                   <option value="kgCO2e / kg">kgCO2e / kg</option>
                                   <option value="tCO2e / mt">tCO2e / mt</option>
                                   <option value="kgCO2e / mt">kgCO2e / mt</option>
-                                  <option value="%">%</option>
                                   <option value="% prior year">% prior year</option>
                                   <option value="% current">% current</option>
                                   <option value="% / year">% / year</option>
-                                  <option value="year old mean weibull">year old (mean life, Weibull)</option>
-                                  <option value="year old exact">year old (exact)</option>
                                 </select>
                               </span>
                             </div>

--- a/editor/js/ace-mode-qubectalk.js
+++ b/editor/js/ace-mode-qubectalk.js
@@ -12,13 +12,13 @@ ace.define("ace/mode/qubectalk", [
       "substance|uses|variables";
 
     const commandKeywords = "across|ago|as|assume|at|by|cap|change|charge|current|" +
-      "continued|during|enable|eol|floor|for|from|get|in|induction|initial|" +
-      "modify|no|of|only|prior|recharge|recover|replace|replacement|retire|reuse|" +
+      "continued|during|enable|eol|exact|floor|for|from|get|in|induction|initial|" +
+      "modify|no|of|old|only|prior|recharge|recover|replace|replacement|retire|reuse|" +
       "set|simulate|then|to|trials|using|volume|with";
 
     const conditionalKeywords = "and|else|endif|if|or|xor";
 
-    const samplingKeywords = "mean|normally|sample|std|uniformly|limit";
+    const samplingKeywords = "mean|normally|sample|std|uniformly|limit|weibull";
 
     const streams = [
       "priorEquipment", "newEquipment", "equipment", "priorBank", "bank", "export", "import",

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = 'org.kigalisim'
-version = '0.2.1'
+version = '0.2.2'
 
 eclipse {
     classpath {
@@ -272,7 +272,7 @@ publishing {
       gpr(MavenPublication) {
         groupId = 'org.kigalisim'
         artifactId = 'engine'
-        version = '0.2.1'
+        version = '0.2.2'
 
         from(components.java)
         artifact fatJarVersion

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,5 +1,5 @@
 # Kigali Sim - Montreal Protocol Policy Simulation Tool
-v=20260804
+v=20260825
 
 Kigali Sim is an open source web-based simulation engine for modeling substances, applications, and policies related to the Montreal Protocol and Kigali Amendment. See [llms.txt](llms.txt) (http://kigalisim.org/llms.txt) for an index of additional documentation and tutorials. It can model high global warming potential greenhouse gases such as HFCs and supports business-as-usual scenarios as well as policy interventions.
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,5 +1,5 @@
 # Kigali Sim
-v=20260804
+v=20260825
 
 Open source web-based simulation engine for Montreal Protocol policy modeling. It is **strongly** recommended to review [llms-full.txt](llms-full.txt) which can be found at http://kigalisim.org/llms-full.txt.
 


### PR DESCRIPTION
## Summary
- Reorder the `retirement-units` dropdown in the Basic Editor so `%` is first, followed by the "year old" options, then the rest of the units in their original order.
- Add ace editor syntax highlighting for the `old`, `exact`, and `weibull` keywords used by the new year-old retirement syntax (`retire N year old exact`, `retire N year old mean weibull`).
- Bump the engine version to 0.2.2 in `engine/build.gradle`.
- Update the `llms.txt` / `llms-full.txt` cache-busting version strings (and all hardcoded `?v=` references across the README and AI-assistant tutorials) from `20260804` to `20260825`.

## Test plan
- [x] `node --check editor/js/ace-mode-qubectalk.js` (syntax check; `eslint` unavailable in this environment due to a missing `eslint.config.js`)
- [x] Manually reviewed the reordered `<select>` markup in `editor/index.html`
- [x] Manually confirmed no other files reference the old `0.2.1` version or `v=20260804` string

---
_Generated by [Claude Code](https://claude.ai/code/session_0121TpuGXwYWqLkbRcduyjan)_