### PR TITLE
Support POST body parameters in Lambda handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ This can be run using the editor tab at https://kigalisim.org/ or locally via `j
 Developers can continue their work by going to the [User Guide](https://kigalisim.org/guide/) which had information on other features. See also the [formal QubecTalk language specification](https://kigalisim.org/guide/qubectalk.pdf).
 
 ### LLM assistants
-If desired, AI coding assistants or chatbots can help in using Kigali Sim. We implement the [llms.txt specification](https://llmstxt.org), a standard that allows users to bring their own LLM assistants to the tool. Direct your AI to read `https://kigalisim.org/llms-full.txt?v=20260825` and / or `https://kigalisim.org/llms.txt?v=20260825`.
+If desired, AI coding assistants or chatbots can help in using Kigali Sim. We implement the [llms.txt specification](https://llmstxt.org), a standard that allows users to bring their own LLM assistants to the tool. Direct your AI to read `https://kigalisim.org/llms-full.txt?v=20260826` and / or `https://kigalisim.org/llms.txt?v=20260826`.
 
 <br>
 

--- a/docs/guide/tutorial_03a.html
+++ b/docs/guide/tutorial_03a.html
@@ -51,10 +51,10 @@
           In this tutorial series, we have used <a href="https://claude.ai/">Claude</a>. However, in practice, most AI assistants can help with Kigali Sim using a standard called <a href="https://llmstxt.org/">llms.txt</a>. So, to get AI ready to go, please create a new chat session. Then, tell it to look up information about Kigali Sim through a message like this:
         </p>
 
-        <pre class="prompt-code"><code>Hello! I would like help with building a Kigali Sim simulation. Please read https://kigalisim.org/llms-full.txt?v=20260825 to learn more. Please stick to only features compatible with the UI editor.</code></pre>
+        <pre class="prompt-code"><code>Hello! I would like help with building a Kigali Sim simulation. Please read https://kigalisim.org/llms-full.txt?v=20260826 to learn more. Please stick to only features compatible with the UI editor.</code></pre>
 
         <p>
-          Need a little cheat? <a href="tutorial_02.qta" download>Download the Tutorial 2</a> file here. Also, for more capable assistants like Claude, this is enough. However, some assistants cannot access the full internet or won't know how to work with this kind of file out of the box. If your assistant is having issues, instead, attach the <a href="https://kigalisim.org/llms-full.txt?v=20260825" download>Kigali Sim llms-full.txt</a> file as an attachment!
+          Need a little cheat? <a href="tutorial_02.qta" download>Download the Tutorial 2</a> file here. Also, for more capable assistants like Claude, this is enough. However, some assistants cannot access the full internet or won't know how to work with this kind of file out of the box. If your assistant is having issues, instead, attach the <a href="https://kigalisim.org/llms-full.txt?v=20260826" download>Kigali Sim llms-full.txt</a> file as an attachment!
         </p>
 
         <p>

--- a/docs/guide/tutorial_04a.html
+++ b/docs/guide/tutorial_04a.html
@@ -61,10 +61,10 @@
           <strong>If you are new to the AI</strong> or just want to start fresh, create a new chat session. Then, tell it to look up information about Kigali Sim through a message like this:
         </p>
 
-        <pre class="prompt-code"><code>Hello! I would like help with building a Kigali Sim simulation. Please read https://kigalisim.org/llms-full.txt?v=20260825 to learn more. Please stick to only features compatible with the UI editor.</code></pre>
+        <pre class="prompt-code"><code>Hello! I would like help with building a Kigali Sim simulation. Please read https://kigalisim.org/llms-full.txt?v=20260826 to learn more. Please stick to only features compatible with the UI editor.</code></pre>
 
         <p>
-          Need a little cheat? <a href="tutorial_03.qta" download>Download the Tutorial 3</a> file here. Also, for more capable assistants like Claude, this is enough. However, some assistants cannot access the full internet or won't know how to work with this kind of file out of the box. If your assistant is having issues, instead, attach the <a href="https://kigalisim.org/llms-full.txt?v=20260825" download>Kigali Sim llms-full.txt</a> file as an attachment!
+          Need a little cheat? <a href="tutorial_03.qta" download>Download the Tutorial 3</a> file here. Also, for more capable assistants like Claude, this is enough. However, some assistants cannot access the full internet or won't know how to work with this kind of file out of the box. If your assistant is having issues, instead, attach the <a href="https://kigalisim.org/llms-full.txt?v=20260826" download>Kigali Sim llms-full.txt</a> file as an attachment!
         </p>
 
         <p>

--- a/docs/guide/tutorial_06a.html
+++ b/docs/guide/tutorial_06a.html
@@ -55,10 +55,10 @@
           In this case, let's create a new chat session. Then, tell it to look up information about Kigali Sim through a message like this:
         </p>
 
-        <pre class="prompt-code"><code>Hello! I would like help with building a Kigali Sim simulation. Please read https://kigalisim.org/llms-full.txt?v=20260825 to learn more. Please stick to only features compatible with the UI editor.</code></pre>
+        <pre class="prompt-code"><code>Hello! I would like help with building a Kigali Sim simulation. Please read https://kigalisim.org/llms-full.txt?v=20260826 to learn more. Please stick to only features compatible with the UI editor.</code></pre>
 
         <p>
-          Need a little cheat? <a href="tutorial_05.qta" download>Download the Tutorial 5</a> file here. Also, for more capable assistants like Claude, this is enough. However, some assistants cannot access the full internet or won't know how to work with this kind of file out of the box. If your assistant is having issues, instead, attach the <a href="https://kigalisim.org/llms-full.txt?v=20260825" download>Kigali Sim llms-full.txt</a> file as an attachment!
+          Need a little cheat? <a href="tutorial_05.qta" download>Download the Tutorial 5</a> file here. Also, for more capable assistants like Claude, this is enough. However, some assistants cannot access the full internet or won't know how to work with this kind of file out of the box. If your assistant is having issues, instead, attach the <a href="https://kigalisim.org/llms-full.txt?v=20260826" download>Kigali Sim llms-full.txt</a> file as an attachment!
         </p>
 
         <p>

--- a/docs/guide/tutorial_11.html
+++ b/docs/guide/tutorial_11.html
@@ -84,7 +84,7 @@
               <a href="https://chatgpt.com/">ChatGPT</a> tends to perform well if given an example. Consider providing a tutorial qta file in your initial prompt like so:
             </p>
 
-            <pre class="prompt-code"><code>Hello! Please review https://preview.kigalisim.org/llms-full.txt?v=20260825 and an example simulation at https://kigalisim.org/guide/tutorial_02.qta. Please follow the structure of that Tutorial 2 with similar keywords and layout in order to write correct QubecTalk code though you may use the other keywords and language features mentioned in llms-full.txt. Please review and then we will build a simulation together.</code></pre>
+            <pre class="prompt-code"><code>Hello! Please review https://preview.kigalisim.org/llms-full.txt?v=20260826 and an example simulation at https://kigalisim.org/guide/tutorial_02.qta. Please follow the structure of that Tutorial 2 with similar keywords and layout in order to write correct QubecTalk code though you may use the other keywords and language features mentioned in llms-full.txt. Please review and then we will build a simulation together.</code></pre>
 
             <p>
               Depending on where you use ChatGPT, it may just give you back code instead of a file. This can be copied and pasted into the <strong>Editor</strong> tab. If you instructed ChatGPT to only use UI-editor compatible code, you can update the code and go back to the <strong>Designer</strong> tab to continue with UI-based authoring.
@@ -108,7 +108,7 @@
               Different versions of copilot might perform differently. See <a href="https://copilot.microsoft.com/">copilot.microsoft.com</a>. In general, Copilot tends to work best when working from an example so you may want to start with a prompt like this:
             </p>
 
-            <pre class="prompt-code"><code>Hello! Please review https://preview.kigalisim.org/llms-full.txt?v=20260825 and an example simulation at https://kigalisim.org/guide/tutorial_02.qta. Please follow the structure of that Tutorial 2 with similar keywords and layout in order to write correct QubecTalk code though you may use the other keywords and language features mentioned in llms-full.txt. Please review and then we will build a simulation together.</code></pre>
+            <pre class="prompt-code"><code>Hello! Please review https://preview.kigalisim.org/llms-full.txt?v=20260826 and an example simulation at https://kigalisim.org/guide/tutorial_02.qta. Please follow the structure of that Tutorial 2 with similar keywords and layout in order to write correct QubecTalk code though you may use the other keywords and language features mentioned in llms-full.txt. Please review and then we will build a simulation together.</code></pre>
 
             <p>
               Depending on where you use Copilot, it may just give you back code instead of a file. This can be copied and pasted into the <strong>Editor</strong> tab. If you instructed Copilot to only use UI-editor compatible code, you can update the code and go back to the <strong>Designer</strong> tab to continue with UI-based authoring.
@@ -123,7 +123,7 @@
               Visit <a href="https://chat.deepseek.com/">chat.deepseek.com</a>. DeepSeek tends to work fairly well but may require a reminder to add the simulations stanza like so:
             </p>
 
-            <pre class="prompt-code"><code>Hello! Please review https://preview.kigalisim.org/llms-full.txt?v=20260825. Then, we will build a simulation together. Please be sure to include the simulation stanza like seen in https://kigalisim.org/guide/tutorial_02.qta.</code></pre>
+            <pre class="prompt-code"><code>Hello! Please review https://preview.kigalisim.org/llms-full.txt?v=20260826. Then, we will build a simulation together. Please be sure to include the simulation stanza like seen in https://kigalisim.org/guide/tutorial_02.qta.</code></pre>
           </div>
         </details>
 
@@ -178,10 +178,10 @@
           At minimum, you should tell your AI to read <a href="https://kigalisim.org/llms.txt" target="_blank">kigalisim.org/llms.txt</a> but we find that providing both <code>llms.txt</code> and <code>llms-full.txt</code> is helpful. Here is how you might want to start.
         </p>
 
-        <pre class="prompt-code"><code>Hello! Please review https://preview.kigalisim.org/llms-full.txt?v=20260825. Then, we will build a simulation together.</code></pre>
+        <pre class="prompt-code"><code>Hello! Please review https://preview.kigalisim.org/llms-full.txt?v=20260826. Then, we will build a simulation together.</code></pre>
 
         <p>
-          <strong>Note</strong>: You may want to review the <a href="#assistants">assistants</a> section for tips on making your specific AI assistant work well. Also, the use of the version (v=20260825) is optional but we recommend it to ensure you have the latest copy.
+          <strong>Note</strong>: You may want to review the <a href="#assistants">assistants</a> section for tips on making your specific AI assistant work well. Also, the use of the version (v=20260826) is optional but we recommend it to ensure you have the latest copy.
         </p>
 
         <p>

--- a/docs/guide/tutorial_11a.html
+++ b/docs/guide/tutorial_11a.html
@@ -100,7 +100,7 @@ We will focus on Domestic Refrigeration first. This is a hypothetical country wi
 
 A few pieces of guidance:
 
- - Before starting, please read https://kigalisim.org/llms-full.txt?v=20260825 to learn more about Kigali Sim.
+ - Before starting, please read https://kigalisim.org/llms-full.txt?v=20260826 to learn more about Kigali Sim.
  - Please use both census data for equipment population and the imports in tonnes if possible to have both datasets support each other.
  - Please lean on Kigali Sim to do calculations where it can be useful including unit conversions, determining substance allocation across different needs, calculating populations, etc.
  - Please use the `.txt` extension for qubectalk files so they are easier to read in chat.

--- a/editor/index.html
+++ b/editor/index.html
@@ -167,12 +167,12 @@
           <p>AI assistants can help you build Kigali Sim simulations by reading and writing QubecTalk code. Direct your assistant to read our documentation and then provide your code for help. For a step-by-step guide, see <a href="/guide/tutorial_11.html" target="_blank">Tutorial 11: AI Coding Assistants</a>.</p>
           <p><strong>Documentation URLs:</strong></p>
           <ul>
-            <li><a href="https://kigalisim.org/llms-full.txt?v=20260825" target="_blank">https://kigalisim.org/llms-full.txt?v=20260825</a> — comprehensive documentation (recommended)</li>
-            <li><a href="https://kigalisim.org/llms.txt?v=20260825" target="_blank">https://kigalisim.org/llms.txt?v=20260825</a> — index with links to tutorials and references</li>
+            <li><a href="https://kigalisim.org/llms-full.txt?v=20260826" target="_blank">https://kigalisim.org/llms-full.txt?v=20260826</a> — comprehensive documentation (recommended)</li>
+            <li><a href="https://kigalisim.org/llms.txt?v=20260826" target="_blank">https://kigalisim.org/llms.txt?v=20260826</a> — index with links to tutorials and references</li>
           </ul>
           <details>
             <summary>More details</summary>
-            <p><strong>Version Parameters:</strong> The version parameter (e.g., ?v=20260825) is optional but recommended. It helps ensure your AI assistant accesses the latest documentation by avoiding cached versions.</p>
+            <p><strong>Version Parameters:</strong> The version parameter (e.g., ?v=20260826) is optional but recommended. It helps ensure your AI assistant accesses the latest documentation by avoiding cached versions.</p>
             <p><strong>Tip:</strong> For LLMs which cannot access the internet, you can <a href="/llms-full.txt" download>download llms-full.txt</a> and provide it as an attachment to your AI assistant.</p>
             <p><strong>Note:</strong> Using AI assistants is entirely optional. Their use is subject to their respective terms of service and privacy policies.</p>
             <p><strong>Privacy:</strong> Using an AI assistant may involve disclosing information about your simulation to the AI and its cloud provider. Be sure to check their privacy policies and any policies negotiated by your organization.</p>
@@ -185,7 +185,7 @@
         <dialog id="ai-designer-dialog">
           <h2>AI Assistant</h2>
           <p>AI assistants can help you build Kigali Sim simulations. Start a chat with any AI assistant and send a message like this:</p>
-          <pre class="prompt-code"><code>Hello! I would like help with building a Kigali Sim simulation. Please read https://kigalisim.org/llms-full.txt?v=20260825 to learn more. Please stick to only features compatible with the UI editor.</code></pre>
+          <pre class="prompt-code"><code>Hello! I would like help with building a Kigali Sim simulation. Please read https://kigalisim.org/llms-full.txt?v=20260826 to learn more. Please stick to only features compatible with the UI editor.</code></pre>
           <p>For a step-by-step walkthrough, see <a href="/guide/tutorial_03a.html" target="_blank">Tutorial 3a: Multiple Substances with AI</a>.</p>
           <details>
             <summary>More details</summary>

--- a/engine/README.md
+++ b/engine/README.md
@@ -91,9 +91,19 @@ To support the community, a public community cloud endpoint is available. Unlike
 
 Endpoint: `https://bbaagift7g5fsza7xzxksl7uny0jjwvn.lambda-url.us-east-2.on.aws/`
 
-Example request (URL-encoded):
+Parameters may be sent either as GET query string parameters or as an `application/x-www-form-urlencoded` POST body using the same parameter names, allowing larger scripts to avoid the practical length limits of a URL. If a parameter is present in both, the POST body value takes precedence.
+
+Example GET request (URL-encoded):
 ```
 GET https://bbaagift7g5fsza7xzxksl7uny0jjwvn.lambda-url.us-east-2.on.aws/?script=start%20default%0A...%0Aend%20default%0A...&simulation=Business%20as%20Usual
+```
+
+Example POST request (form-encoded body), preferred for larger scripts:
+```
+POST https://bbaagift7g5fsza7xzxksl7uny0jjwvn.lambda-url.us-east-2.on.aws/
+Content-Type: application/x-www-form-urlencoded
+
+script=start%20default%0A...%0Aend%20default%0A...&simulation=Business%20as%20Usual
 ```
 
 The `simulation` parameter accepts comma-separated scenario names (e.g., `simulation=Scenario+One,Scenario+Two`) to run multiple simulations in a single call and receive their results combined in one CSV response.

--- a/engine/src/main/java/org/kigalisim/cloud/InvocationParametersFactory.java
+++ b/engine/src/main/java/org/kigalisim/cloud/InvocationParametersFactory.java
@@ -6,8 +6,13 @@
 
 package org.kigalisim.cloud;
 
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -20,6 +25,31 @@ import java.util.stream.Collectors;
  * future requires changes only to this class and {@link InvocationParameters}.</p>
  */
 public class InvocationParametersFactory {
+
+  /**
+   * Builds an {@link InvocationParameters} from an incoming Lambda HTTP event.
+   *
+   * <p>Parameters may be supplied either as GET query string parameters or as a
+   * {@code application/x-www-form-urlencoded} POST body, allowing callers with larger
+   * scripts to avoid URL length limits by sending the script as a POST parameter instead.
+   * When a parameter is present in both the query string and the body, the body value
+   * takes precedence.</p>
+   *
+   * @param event The incoming API Gateway V2 HTTP event.
+   * @return A new {@link InvocationParameters} with the extracted values.
+   */
+  public static InvocationParameters build(APIGatewayV2HTTPEvent event) {
+    Map<String, String> combined = new HashMap<>();
+
+    Map<String, String> queryParams = event.getQueryStringParameters();
+    if (queryParams != null) {
+      combined.putAll(queryParams);
+    }
+
+    combined.putAll(parseFormBody(event));
+
+    return build(combined);
+  }
 
   /**
    * Builds an {@link InvocationParameters} from the given query string parameter map.
@@ -71,6 +101,39 @@ public class InvocationParametersFactory {
         simulations,
         replicates
     );
+  }
+
+  /**
+   * Parses an {@code application/x-www-form-urlencoded} request body into a parameter map.
+   *
+   * @param event The incoming API Gateway V2 HTTP event.
+   * @return A map of parameter names to values parsed from the body, empty if the body is
+   *     absent or blank.
+   */
+  private static Map<String, String> parseFormBody(APIGatewayV2HTTPEvent event) {
+    String body = event.getBody();
+    if (body == null || body.isBlank()) {
+      return Collections.emptyMap();
+    }
+
+    if (event.getIsBase64Encoded()) {
+      body = new String(Base64.getDecoder().decode(body), StandardCharsets.UTF_8);
+    }
+
+    Map<String, String> parsed = new HashMap<>();
+    for (String pair : body.split("&")) {
+      if (pair.isEmpty()) {
+        continue;
+      }
+      int separatorIndex = pair.indexOf('=');
+      String key = separatorIndex < 0 ? pair : pair.substring(0, separatorIndex);
+      String value = separatorIndex < 0 ? "" : pair.substring(separatorIndex + 1);
+      parsed.put(
+          URLDecoder.decode(key, StandardCharsets.UTF_8),
+          URLDecoder.decode(value, StandardCharsets.UTF_8)
+      );
+    }
+    return parsed;
   }
 
 }

--- a/engine/src/main/java/org/kigalisim/cloud/SimulationHandler.java
+++ b/engine/src/main/java/org/kigalisim/cloud/SimulationHandler.java
@@ -24,10 +24,13 @@ import org.kigalisim.lang.parse.ParseResult;
 import org.kigalisim.lang.program.ParsedProgram;
 
 /**
- * Lambda handler that accepts a QubecTalk script via query string and returns CSV output.
+ * Lambda handler that accepts a QubecTalk script via GET query string or POST body and
+ * returns CSV output.
  *
- * <p>Implements the AWS Lambda Function URL / API Gateway HTTP API contract. If one or more
- * comma-separated {@code simulation} names are provided, the handler runs the requested
+ * <p>Implements the AWS Lambda Function URL / API Gateway HTTP API contract. Parameters may
+ * be supplied as GET query string parameters or as an {@code application/x-www-form-urlencoded}
+ * POST body, the latter allowing larger scripts than a URL can comfortably carry. If one or
+ * more comma-separated {@code simulation} names are provided, the handler runs the requested
  * number of replicates of each named scenario in order and returns all results combined in a
  * single CSV response with {@code Content-Type: text/csv}. If {@code simulation} is omitted,
  * the script is validated only and a header-only CSV is returned with status 200.</p>
@@ -52,7 +55,8 @@ public class SimulationHandler
   /**
    * Handles an incoming Lambda HTTP event by running a QubecTalk simulation.
    *
-   * @param event The API Gateway V2 HTTP event containing query string parameters.
+   * @param event The API Gateway V2 HTTP event containing query string parameters and / or a
+   *     form-urlencoded POST body.
    * @param context The Lambda execution context (unused).
    * @return An API Gateway V2 HTTP response with either CSV output or a plain-text error.
    */
@@ -73,15 +77,14 @@ public class SimulationHandler
   /**
    * Handles an incoming Lambda HTTP event, allowing exceptions to propagate.
    *
-   * @param event The API Gateway V2 HTTP event containing query string parameters.
+   * @param event The API Gateway V2 HTTP event containing query string parameters and / or a
+   *     form-urlencoded POST body.
    * @return An API Gateway V2 HTTP response with either CSV output or a plain-text error.
    * @throws Exception if an unexpected error occurs during processing.
    */
   private APIGatewayV2HTTPResponse handleRequestUnsafe(
       APIGatewayV2HTTPEvent event) throws Exception {
-    InvocationParameters params = InvocationParametersFactory.build(
-        event.getQueryStringParameters()
-    );
+    InvocationParameters params = InvocationParametersFactory.build(event);
 
     Optional<String> script = params.getScript();
     if (!script.isPresent()) {

--- a/engine/src/test/java/org/kigalisim/cloud/SimulationHandlerTest.java
+++ b/engine/src/test/java/org/kigalisim/cloud/SimulationHandlerTest.java
@@ -13,6 +13,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPResponse;
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -50,6 +52,25 @@ public class SimulationHandlerTest {
   private APIGatewayV2HTTPEvent buildEvent(Map<String, String> params) {
     return APIGatewayV2HTTPEvent.builder()
         .withQueryStringParameters(params)
+        .build();
+  }
+
+  /**
+   * Builds a minimal APIGatewayV2HTTPEvent simulating a form-urlencoded POST body built from
+   * the given parameters.
+   *
+   * @param params Parameters to encode into the POST body.
+   * @return A constructed event object with no query string parameters.
+   */
+  private APIGatewayV2HTTPEvent buildPostEvent(Map<String, String> params) {
+    String body = params.entrySet().stream()
+        .map(entry -> URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8)
+            + "="
+            + URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8))
+        .reduce((first, second) -> first + "&" + second)
+        .orElse("");
+    return APIGatewayV2HTTPEvent.builder()
+        .withBody(body)
         .build();
   }
 
@@ -391,6 +412,74 @@ public class SimulationHandlerTest {
         (oneReplicateRows - 1) * 3 + 1,
         response.getBody().split("\n").length,
         "Three replicates should produce three times the data rows plus one header"
+    );
+  }
+
+  /**
+   * Test that a script sent as a form-urlencoded POST body (no query string) runs correctly.
+   */
+  @Test
+  public void testScriptAsPostBodyReturns200() {
+    Map<String, String> params = new HashMap<>();
+    params.put("script", oneScenarioScript);
+    params.put("simulation", "Business as Usual");
+    APIGatewayV2HTTPEvent event = buildPostEvent(params);
+    APIGatewayV2HTTPResponse response = handler.handleRequest(event, null);
+    assertEquals(
+        200,
+        response.getStatusCode(),
+        "Script provided as POST body should return 200"
+    );
+    assertTrue(
+        response.getBody().contains("Business as Usual"),
+        "POST body response should contain simulation results"
+    );
+  }
+
+  /**
+   * Test that a missing script in both the query string and the POST body returns HTTP 400.
+   */
+  @Test
+  public void testMissingScriptInPostBodyReturns400() {
+    Map<String, String> params = new HashMap<>();
+    params.put("simulation", "Business as Usual");
+    APIGatewayV2HTTPEvent event = buildPostEvent(params);
+    APIGatewayV2HTTPResponse response = handler.handleRequest(event, null);
+    assertEquals(
+        400,
+        response.getStatusCode(),
+        "Missing script in POST body should return 400"
+    );
+  }
+
+  /**
+   * Test that a POST body parameter takes precedence over a query string parameter with the
+   * same name.
+   */
+  @Test
+  public void testPostBodyTakesPrecedenceOverQueryString() {
+    Map<String, String> bodyParams = new HashMap<>();
+    bodyParams.put("script", oneScenarioScript);
+    bodyParams.put("simulation", "Business as Usual");
+    String body = bodyParams.entrySet().stream()
+        .map(entry -> URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8)
+            + "="
+            + URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8))
+        .reduce((first, second) -> first + "&" + second)
+        .orElse("");
+
+    Map<String, String> queryParams = new HashMap<>();
+    queryParams.put("script", "not valid qubectalk");
+
+    APIGatewayV2HTTPEvent event = APIGatewayV2HTTPEvent.builder()
+        .withQueryStringParameters(queryParams)
+        .withBody(body)
+        .build();
+    APIGatewayV2HTTPResponse response = handler.handleRequest(event, null);
+    assertEquals(
+        200,
+        response.getStatusCode(),
+        "POST body script should take precedence over an invalid query string script"
     );
   }
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,5 +1,5 @@
 # Kigali Sim - Montreal Protocol Policy Simulation Tool
-v=20260825
+v=20260826
 
 Kigali Sim is an open source web-based simulation engine for modeling substances, applications, and policies related to the Montreal Protocol and Kigali Amendment. See [llms.txt](llms.txt) (http://kigalisim.org/llms.txt) for an index of additional documentation and tutorials. It can model high global warming potential greenhouse gases such as HFCs and supports business-as-usual scenarios as well as policy interventions.
 
@@ -438,11 +438,19 @@ The `validate` subcommand parses and interprets the file without executing simul
 
 **Privacy notice**: Before invoking this endpoint on a user's behalf for the first time, confirm that the user is comfortable with their simulation code being sent to a remote server. A brief, friendly confirmation is sufficient — one or two sentences, not a lengthy disclaimer. Only use this endpoint if you are unable to run the JAR engine locally. A suggested prompt: "I cannot execute this simulation on my own but the University of California offers a service through which I can get results privately. This involves sending our simulation to them to execute but they keep it in confidence, only using the simulation we provide to generate results for us and they do not keep a copy. Is it OK to use this tool?" Though subject to the data processing addendum of the cloud provider, the Kigali Sim remote code does not log simulation content. See https://kigalisim.org/privacy.html for full details.
 
-A public GET endpoint at `https://bbaagift7g5fsza7xzxksl7uny0jjwvn.lambda-url.us-east-2.on.aws/` accepts a URL-encoded QubecTalk script via the `script` query parameter and returns simulation results as CSV. No authentication is required. The `simulation` parameter accepts one or more comma-separated scenario names to run; if omitted or blank, the script is validated and a header-only CSV is returned with status 200. When multiple names are provided, all scenarios are run in the order given and their results are combined into a single CSV response. An optional `replicates` integer parameter controls how many times each simulation is run (default: 1); all replicate results are combined into the single CSV response. A value less than 1 returns HTTP 400. The CSV response contains the standard output columns: `scenario`, `trial`, `year`, `application`, `substance`, `domestic`, `import`, `recycle`, `domesticConsumption`, `importConsumption`, `recycleConsumption`, `population`, `populationNew`, `rechargeEmissions`, `eolEmissions`, `initialChargeEmissions`, `energyConsumption`, `export`, `exportConsumption`, `importInitialChargeValue`, `importInitialChargeConsumption`, `importPopulation`, `exportInitialChargeValue`, `exportInitialChargeConsumption`, `bankKg`, `bankTCO2e`, `bankChangeKg`, `bankChangeTCO2e`. The remote server does not log simulation content. See https://kigalisim.org/privacy.html for full details.
+A public endpoint at `https://bbaagift7g5fsza7xzxksl7uny0jjwvn.lambda-url.us-east-2.on.aws/` accepts a URL-encoded QubecTalk script via the `script` parameter and returns simulation results as CSV. No authentication is required. The `script` (and other) parameters may be supplied either as GET query string parameters or as an `application/x-www-form-urlencoded` POST body using the same parameter names; if a parameter is present in both, the POST body value takes precedence. Prefer POST for longer scripts since URLs have practical length limits that a query string can exceed, while a POST body does not have this constraint. The `simulation` parameter accepts one or more comma-separated scenario names to run; if omitted or blank, the script is validated and a header-only CSV is returned with status 200. When multiple names are provided, all scenarios are run in the order given and their results are combined into a single CSV response. An optional `replicates` integer parameter controls how many times each simulation is run (default: 1); all replicate results are combined into the single CSV response. A value less than 1 returns HTTP 400. The CSV response contains the standard output columns: `scenario`, `trial`, `year`, `application`, `substance`, `domestic`, `import`, `recycle`, `domesticConsumption`, `importConsumption`, `recycleConsumption`, `population`, `populationNew`, `rechargeEmissions`, `eolEmissions`, `initialChargeEmissions`, `energyConsumption`, `export`, `exportConsumption`, `importInitialChargeValue`, `importInitialChargeConsumption`, `importPopulation`, `exportInitialChargeValue`, `exportInitialChargeConsumption`, `bankKg`, `bankTCO2e`, `bankChangeKg`, `bankChangeTCO2e`. The remote server does not log simulation content. See https://kigalisim.org/privacy.html for full details.
 
-Example:
+Example (GET, suitable for short scripts):
 ```
 GET https://bbaagift7g5fsza7xzxksl7uny0jjwvn.lambda-url.us-east-2.on.aws/?script=start%20default%0A%20%20define%20application%20%22dom%20refrig%22%0A%20%20%20%20uses%20substance%20%22HFC-134a%22%0A%20%20%20%20%20%20enable%20domestic%0A%20%20%20%20%20%20equals%201430%20kgCO2e%20%2F%20kg%0A%20%20%20%20%20%20set%20domestic%20to%201%20mt%20during%20year%201%0A%20%20%20%20end%20substance%0A%20%20end%20application%0Aend%20default%0Astart%20simulations%0A%20%20simulate%20%22BAU%22%20from%20years%201%20to%205%0Aend%20simulations&simulation=BAU
+```
+
+Example (POST, preferred for larger scripts):
+```
+POST https://bbaagift7g5fsza7xzxksl7uny0jjwvn.lambda-url.us-east-2.on.aws/
+Content-Type: application/x-www-form-urlencoded
+
+script=start%20default%0A...%0Aend%20default%0A...&simulation=BAU
 ```
 
 ## Technical Implementation

--- a/llms.txt
+++ b/llms.txt
@@ -1,5 +1,5 @@
 # Kigali Sim
-v=20260825
+v=20260826
 
 Open source web-based simulation engine for Montreal Protocol policy modeling. It is **strongly** recommended to review [llms-full.txt](llms-full.txt) which can be found at http://kigalisim.org/llms-full.txt.
 


### PR DESCRIPTION
## Summary
Extended the Lambda HTTP handler to accept simulation parameters via `application/x-www-form-urlencoded` POST body in addition to GET query string parameters. This allows callers to submit larger scripts that would exceed practical URL length limits.

## Key Changes

- **InvocationParametersFactory**: Added new `build(APIGatewayV2HTTPEvent)` method that:
  - Extracts parameters from both query string and form-encoded POST body
  - Implements POST body parameter precedence over query string when both are present
  - Handles base64-encoded bodies
  - Parses URL-encoded form data with proper UTF-8 decoding

- **SimulationHandler**: Updated to use the new factory method that accepts the full HTTP event instead of just query parameters

- **Tests**: Added comprehensive test coverage:
  - `testScriptAsPostBodyReturns200`: Validates script execution via POST body
  - `testMissingScriptInPostBodyReturns400`: Ensures validation still works for POST
  - `testPostBodyTakesPrecedenceOverQueryString`: Verifies parameter precedence behavior

- **Documentation**: Updated README and llms-full.txt to document the new POST capability with examples

## Implementation Details

The `parseFormBody()` method handles:
- Null/blank body detection
- Base64 decoding when `isBase64Encoded` flag is set
- Proper URL decoding of both keys and values using UTF-8
- Empty pair skipping in the split operation
- Graceful handling of malformed pairs (missing `=` separator)

Parameters from both sources are merged into a single map with POST body values overwriting query string values of the same name.

https://claude.ai/code/session_01MsUvEwuyoMDez4zrnjq76k