### PR TITLE
Fix llms-full.txt worked example: new substance can't be introduced via `uses substance` in a modify application block

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -295,6 +295,19 @@ start default
       retire 6.7 % each year
       recharge 10 % with 0.12 kg / unit
     end substance
+
+    uses substance "R-600a"
+      enable domestic
+      enable import
+      equals 6 tCO2e / mt
+      equals 95 kwh / unit
+
+      initial charge with 0.05 kg / unit for domestic
+      initial charge with 0.05 kg / unit for import
+
+      retire 6.7 % each year
+      recharge 10 % with 0.05 kg / unit
+    end substance
   end application
 end default
 
@@ -308,12 +321,6 @@ start policy "HFC Phasedown"
 
       # Example: Age-dependent retirement (can be typed as a formula into a Basic Editor numeric field)
       # retire (get age as years) * 1 % each year during years 5 to onwards
-    end substance
-
-    uses substance "R-600a"
-      equals 6 tCO2e / mt
-      equals 95 kwh / unit
-      initial charge with 0.05 kg / unit for domestic
     end substance
   end application
 end policy


### PR DESCRIPTION
The QubecTalk grammar only allows `modify substance` (not `uses substance`) inside
`modify application` within a policy, so the documented R-600a example failed to
parse. Predefine R-600a alongside HFC-134a in the default stanza (matching the
pattern already used in docs/spec/qubectalk.md) so the policy's `replace ...
with "R-600a"` has a substance to target, and drop the invalid block from the
policy. Verified the corrected example runs end-to-end via the engine's run
command.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016BbL2SXGnv7qQkPSWFNFEA