### PR TITLE
Net EOL recycling against eolEmissions instead of rechargeEmissions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,7 +20,7 @@ The following changes have been adopted and released.
 
 **Classification**: Clarification
 
-Clarified that substance recovered and reused through recycling `at eol` is now netted against end of life emissions instead of servicing (recharge) emissions. Historically, all recycling, regardless of stage, offset the reported servicing emissions figure, an approach originally reasonable when recycling was primarily modeled at recharge. As `at eol` recycling has seen more use, this could leave end of life emissions fully unreduced by that recovered material while servicing emissions were driven negative to compensate, even in simulations with no recharge at all. Emissions are now offset at the stage the recycling actually happens: recycling `at recharge` continues to net against servicing emissions, while recycling `at eol` nets against end of life emissions, with both floored at zero. We have added tests to prevent regression.
+Clarified that substance recovered and reused through recycling `at eol` is now netted against end of life emissions instead of servicing (recharge) emissions. Historically, all recycling, regardless of stage, offset the reported servicing emissions figure. As `at eol` recycling has seen more use, this could lead to confusion even if the numbers are correct.
 
 ### End of Life Recycling Fix
 

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,14 @@ Finally, we want to again express our gratitude for your feedback and time.
 
 The following changes have been adopted and released.
 
+### End of Life Recycling Emissions Attribution
+
+**Status**: Released September 4, 2026.
+
+**Classification**: Clarification
+
+Clarified that substance recovered and reused through recycling `at eol` is now netted against end of life emissions instead of servicing (recharge) emissions. Historically, all recycling, regardless of stage, offset the reported servicing emissions figure, an approach originally reasonable when recycling was primarily modeled at recharge. As `at eol` recycling has seen more use, this could leave end of life emissions fully unreduced by that recovered material while servicing emissions were driven negative to compensate, even in simulations with no recharge at all. Emissions are now offset at the stage the recycling actually happens: recycling `at recharge` continues to net against servicing emissions, while recycling `at eol` nets against end of life emissions, with both floored at zero. We have added tests to prevent regression.
+
 ### End of Life Recycling Fix
 
 **Status**: Released September 3, 2026.

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = 'org.kigalisim'
-version = '0.2.3'
+version = '0.2.4'
 
 eclipse {
     classpath {
@@ -272,7 +272,7 @@ publishing {
       gpr(MavenPublication) {
         groupId = 'org.kigalisim'
         artifactId = 'engine'
-        version = '0.2.3'
+        version = '0.2.4'
 
         from(components.java)
         artifact fatJarVersion

--- a/engine/src/main/java/org/kigalisim/engine/serializer/EngineResultSerializer.java
+++ b/engine/src/main/java/org/kigalisim/engine/serializer/EngineResultSerializer.java
@@ -108,8 +108,28 @@ public class EngineResultSerializer {
     EngineNumber populationNew = engine.getStreamFor(useKey, "newEquipment");
     builder.setPopulationNew(populationNew);
 
+    // Get consumption rate, needed below to net recycling out of eol and recharge emissions
+    EngineNumber consumptionByVolume = getConsumptionByVolume(
+        useKey,
+        unitConverter
+    );
+
+    // Offset EOL emissions by the substance recovered and reused at end-of-life, since
+    // that volume is displaced rather than emitted to atmosphere.
     EngineNumber eolEmissions = engine.getStreamFor(useKey, "eolEmissions");
-    builder.setEolEmissions(eolEmissions);
+    EngineNumber recycleEolRaw = engine.getStreamFor(useKey, "recycleEol");
+    EngineNumber recycleEolValue = unitConverter.convert(recycleEolRaw, "kg");
+    EngineNumber recycleEolConsumptionValue = getConsumptionForVolume(
+        recycleEolValue,
+        consumptionByVolume,
+        stateGetter,
+        unitConverter
+    );
+    EngineNumber eolEmissionsConvert = unitConverter.convert(eolEmissions, "tCO2e");
+    BigDecimal eolEmissionsOffsetValue = eolEmissionsConvert.getValue()
+        .subtract(recycleEolConsumptionValue.getValue())
+        .max(BigDecimal.ZERO);
+    builder.setEolEmissions(new EngineNumber(eolEmissionsOffsetValue, "tCO2e"));
 
     // Calculate initial charge emissions
     EngineNumber initialChargeEmissions = calculateInitialChargeEmissions(useKey);
@@ -141,12 +161,6 @@ public class EngineResultSerializer {
     // Use values directly - recycling already handled at stream level
     builder.setDomesticValue(manufactureValue);
     builder.setImportValue(importValue);
-
-    // Get consumption
-    EngineNumber consumptionByVolume = getConsumptionByVolume(
-        useKey,
-        unitConverter
-    );
 
     EngineNumber domesticConsumptionValue = getConsumptionForVolume(
         manufactureValue,
@@ -189,17 +203,29 @@ public class EngineResultSerializer {
     );
     builder.setRecycleConsumptionValue(recycleConsumptionValue);
 
-    // Offset recharge emissions
+    // Offset recharge emissions by the substance recovered and reused at recharge (servicing)
+    // time, since that volume is displaced rather than emitted to atmosphere. Recycling at
+    // end-of-life is netted against eolEmissions above instead, not here.
     EngineNumber rechargeEmissions = engine.getStreamFor(
         useKey,
         "rechargeEmissions"
+    );
+    EngineNumber recycleRechargeRaw = engine.getStreamFor(useKey, "recycleRecharge");
+    EngineNumber recycleRechargeValue = unitConverter.convert(recycleRechargeRaw, "kg");
+    EngineNumber recycleRechargeConsumptionValue = getConsumptionForVolume(
+        recycleRechargeValue,
+        consumptionByVolume,
+        stateGetter,
+        unitConverter
     );
     OverridingConverterStateGetter clearStateGetter =
         new OverridingConverterStateGetter(this.stateGetter);
     UnitConverter clearUnitConverter = new UnitConverter(clearStateGetter);
     EngineNumber rechargeEmissionsConvert = clearUnitConverter.convert(rechargeEmissions, "tCO2e");
-    EngineNumber rechargeEmissionsOffset = new EngineNumber(
-        rechargeEmissionsConvert.getValue().subtract(recycleConsumptionValue.getValue()), "tCO2e");
+    BigDecimal rechargeEmissionsOffsetValue = rechargeEmissionsConvert.getValue()
+        .subtract(recycleRechargeConsumptionValue.getValue())
+        .max(BigDecimal.ZERO);
+    EngineNumber rechargeEmissionsOffset = new EngineNumber(rechargeEmissionsOffsetValue, "tCO2e");
     builder.setRechargeEmissions(rechargeEmissionsOffset);
   }
 

--- a/engine/src/test/java/org/kigalisim/engine/serializer/EngineResultSerializerTest.java
+++ b/engine/src/test/java/org/kigalisim/engine/serializer/EngineResultSerializerTest.java
@@ -147,11 +147,12 @@ public class EngineResultSerializerTest {
      */
     @Test
     public void testGetsRechargeEmissions() {
-      // Expected: 1000 mt converted to tCO2e (500,000) - 5000 tCO2e (recycle consumption)
-      // = 495,000 tCO2e
+      // Expected: 1000 mt converted to tCO2e (500,000) - only the recharge-stage recycling
+      // (5 mt * 500 tCO2e/mt = 2,500 tCO2e) is netted out here, not the eol-stage half
+      // (which is netted against eolEmissions instead), so 500,000 - 2,500 = 497,500 tCO2e
       assertEquals(0, result.getRechargeEmissions().getValue()
-          .compareTo(BigDecimal.valueOf(495000)),
-          "Recharge emissions should be 495,000 tCO2e");
+          .compareTo(BigDecimal.valueOf(497500)),
+          "Recharge emissions should be 497,500 tCO2e");
       assertEquals("tCO2e", result.getRechargeEmissions().getUnits(),
           "Recharge emissions units should be tCO2e");
     }
@@ -161,9 +162,10 @@ public class EngineResultSerializerTest {
      */
     @Test
     public void testGetsEolEmissions() {
-      // Expected: 100 tCO2e
-      assertEquals(0, result.getEolEmissions().getValue().compareTo(BigDecimal.valueOf(100)),
-          "EOL emissions should be 100 tCO2e");
+      // Expected: 100 tCO2e gross - eol-stage recycling (5 mt * 500 tCO2e/mt = 2,500 tCO2e)
+      // netted out, clamped at 0 since recycling exceeds the gross figure in this test data
+      assertEquals(0, result.getEolEmissions().getValue().compareTo(BigDecimal.ZERO),
+          "EOL emissions should be 0 tCO2e once eol-stage recycling is netted out");
       assertEquals("tCO2e", result.getEolEmissions().getUnits(),
           "EOL emissions units should be tCO2e");
     }

--- a/engine/src/test/java/org/kigalisim/validate/RecycleRecoverLiveTests.java
+++ b/engine/src/test/java/org/kigalisim/validate/RecycleRecoverLiveTests.java
@@ -1939,4 +1939,40 @@ public class RecycleRecoverLiveTests {
     }
   }
 
+  /**
+   * Test that 100% recovery and reuse "at eol" nets eolEmissions down to zero rather than
+   * leaving eolEmissions at its full gross value while rechargeEmissions goes negative.
+   *
+   * <p>This is a regression test for a bug where the serializer subtracted the combined
+   * eol-stage and recharge-stage recycling volume from {@code rechargeEmissions} alone (see
+   * {@link org.kigalisim.engine.serializer.EngineResultSerializer}), while never netting
+   * {@code eolEmissions} against the recycling that happened at end-of-life. With a policy that
+   * only recovers "at eol", this made rechargeEmissions negative (since there was no recharge to
+   * offset against) while eolEmissions stayed fully unreduced, even though the recovered
+   * material displaces end-of-life emissions rather than recharge emissions.</p>
+   */
+  @Test
+  public void testRecycleAtEolNetsEolEmissionsNotRechargeEmissions() throws IOException {
+    // Load and parse the QTA file
+    String qtaPath = "../examples/recycle_eol_exact_age_steady_state.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    // Run the scenario with recycling active from year 7 onward
+    Stream<EngineResult> results = KigaliSimFacade.runScenario(program, "with recycle", progress -> {});
+    List<EngineResult> resultsList = results.collect(Collectors.toList());
+
+    // From year 7 onward, 100% of retiring equipment's charge is recovered and reused "at eol",
+    // so eolEmissions should be fully netted to zero and rechargeEmissions (there being no
+    // recharge in this scenario) should never go negative.
+    for (int year = 7; year <= 17; year++) {
+      EngineResult record = LiveTestsUtil.getResult(resultsList.stream(), year, "test", "test");
+      assertNotNull(record, "Should have result for test/test in year " + year);
+      assertEquals(0.0, record.getEolEmissions().getValue().doubleValue(), 0.0001,
+          "EOL emissions should be fully netted to zero by 100% recovery/reuse in year " + year);
+      assertEquals(0.0, record.getRechargeEmissions().getValue().doubleValue(), 0.0001,
+          "Recharge emissions should not go negative from eol-stage recycling in year " + year);
+    }
+  }
+
 }


### PR DESCRIPTION
## Summary
Fixed a bug in emission offset calculations where recycled refrigerant recovered at end-of-life was incorrectly netted against recharge emissions instead of EOL emissions. This caused recharge emissions to go negative when policies recovered material only at end-of-life, while EOL emissions remained unreduced.

## Key Changes
- **Moved consumption calculation earlier**: Moved `getConsumptionByVolume()` call to the beginning of `parseMainBody()` so it's available for both EOL and recharge offset calculations
- **Added EOL-stage recycling offset**: Introduced logic to net `recycleEol` (end-of-life recovered material) against `eolEmissions`, converting both to consistent units and applying the offset
- **Fixed recharge offset logic**: Changed recharge emissions offset to only subtract `recycleRecharge` (recharge-stage recovered material) instead of the combined recycling volume
- **Added zero-floor clamping**: Both EOL and recharge emission offsets now use `.max(BigDecimal.ZERO)` to prevent negative values when recycling exceeds gross emissions
- **Updated test expectations**: Adjusted unit tests to reflect the corrected behavior where EOL recycling reduces `eolEmissions` and recharge recycling reduces `rechargeEmissions` independently

## Implementation Details
- The fix properly separates the two recycling streams: `recycleEol` offsets `eolEmissions`, while `recycleRecharge` offsets `rechargeEmissions`
- Both offsets are converted to "tCO2e" units for consistency before subtraction
- Added regression test `testRecycleAtEolNetsEolEmissionsNotRechargeEmissions()` to prevent this bug from recurring

https://claude.ai/code/session_01FWiLgou4PhuPkEvpyFLWBV